### PR TITLE
Add optional Unix-socket pubsub backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -710,7 +710,7 @@ Sidereal.configure do |c|
 end
 ```
 
-A custom store must respond to `#append(message)`. A custom dispatcher must respond to `.spawn_into(task)` (class-level) and `#stop`.
+A custom store must respond to `#append(message)`. A custom dispatcher must respond to `.start(task)` (class-level) and `#stop`.
 
 ## How it works
 

--- a/benchmark/unix_pubsub.rb
+++ b/benchmark/unix_pubsub.rb
@@ -1,0 +1,208 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# Benchmark for Sidereal::PubSub::Unix throughput and concurrent subscribers.
+#
+# Each subscriber fiber owns a unique channel ("bench.<i>"). The publisher
+# round-robins across channels, publishing one message per subscriber per
+# round. Total messages = subscribers × rounds; every message hits exactly
+# one subscriber (no fan-out amplification — what we're measuring is the
+# raw publish→deliver pipeline, scaled by N concurrent fibers).
+#
+# Modes:
+#   --inproc  publisher and subscribers in the same process. Local delivery
+#             dominates (deliver_local before the wire write); the broker
+#             fan-out is a no-op because the publisher's own peer is the
+#             only one and is excluded from fan-out.
+#   --xproc   subscribers in the parent, publisher in a forked child. Frames
+#             traverse the socket: publisher → broker (parent) → loopback
+#             peer in parent → read loop → deliver_local. This is the
+#             realistic cross-process path Sidereal apps see in production.
+#
+# Each message embeds CLOCK_MONOTONIC at publish time; the subscriber
+# computes (receive - publish) for per-message latency. CLOCK_MONOTONIC is
+# system-wide on Linux/macOS so the publisher and subscriber clocks are
+# directly comparable.
+#
+# Reported `elapsed` is computed from message timestamps:
+#
+#   elapsed = max(receive_ns) - min(publish_ns)
+#
+# i.e. from the moment the first message was published to the moment the
+# last one was received. This deliberately excludes the warmup sleep, the
+# cross-process startup-coordination lag, and the tail polling sleep — so
+# `rate = total / elapsed` is a clean publish-to-deliver throughput.
+#
+# Usage:
+#   bundle exec ruby benchmark/unix_pubsub.rb [options]
+#
+# Examples:
+#   benchmark/unix_pubsub.rb                            # 10 subs × 1000 rounds, in-process
+#   benchmark/unix_pubsub.rb -n 50 -m 2000              # 50 subs × 2000 rounds
+#   benchmark/unix_pubsub.rb --xproc                    # cross-process
+#   benchmark/unix_pubsub.rb --xproc -n 100 -m 5000     # heavier x-process
+
+require 'optparse'
+require 'tmpdir'
+
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
+require 'sidereal'
+require 'sidereal/pubsub/unix'
+
+opts = {
+  subscribers: 10,
+  rounds:      1_000,
+  mode:        :inproc
+}
+
+OptionParser.new do |o|
+  o.banner = 'Usage: bundle exec ruby benchmark/unix_pubsub.rb [options]'
+  o.on('-n', '--subscribers N', Integer, 'Number of subscriber fibers (default 10)') { |n| opts[:subscribers] = n }
+  o.on('-m', '--rounds M', Integer, 'Messages published per subscriber (default 1000)') { |n| opts[:rounds] = n }
+  o.on('--inproc', 'Single-process loopback (default)') { opts[:mode] = :inproc }
+  o.on('--xproc',  'Publisher in a forked child') { opts[:mode] = :xproc }
+  o.on('-h', '--help') { puts o; exit }
+end.parse!
+
+# Silence the JSON log noise (election INFO lines, transient ECONNREFUSED
+# WARN during the startup race) so only the numeric output is on stdout.
+# Set CONSOLE_LEVEL=warn or =info to see them.
+require 'logger'
+Console.logger.level = Logger::ERROR unless ENV['CONSOLE_LEVEL']
+
+BenchMsg = Sidereal::Message.define('bench.event') do
+  attribute :seq,        ::Integer
+  attribute :publish_ns, ::Integer
+end
+
+def now_ns = Process.clock_gettime(Process::CLOCK_MONOTONIC, :nanosecond)
+def now_s  = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+def percentile(sorted, pct)
+  return 0 if sorted.empty?
+
+  i = ((pct / 100.0) * (sorted.size - 1)).round
+  sorted[i]
+end
+
+def report(label, opts, total, elapsed_s, latencies_ns)
+  rate = elapsed_s.zero? ? 0 : (total / elapsed_s)
+  sorted = latencies_ns.sort
+  printf("%-7s subs=%-4d rounds=%-6d total=%-7d elapsed=%6.3fs rate=%9.0f msg/s",
+         label, opts[:subscribers], opts[:rounds], total, elapsed_s, rate)
+  unless sorted.empty?
+    printf("   latency μs p50=%-7d p95=%-7d p99=%-7d max=%-7d",
+           percentile(sorted, 50) / 1_000,
+           percentile(sorted, 95) / 1_000,
+           percentile(sorted, 99) / 1_000,
+           sorted.last / 1_000)
+  end
+  puts
+end
+
+# Use a generous write-queue ceiling so the broker doesn't drop slow peers
+# during a heavy benchmark — any drop would skew numbers.
+def build(root)
+  Sidereal::PubSub::Unix.new(
+    socket_path:      File.join(root, 'p.sock'),
+    lock_path:        File.join(root, 'p.lock'),
+    write_queue_size: 1_000_000
+  )
+end
+
+def publish_round_robin(pubsub, opts)
+  opts[:rounds].times do |seq|
+    opts[:subscribers].times do |i|
+      pubsub.publish(
+        "bench.#{i}",
+        BenchMsg.new(payload: { seq: seq, publish_ns: now_ns })
+      )
+    end
+  end
+end
+
+# Wire up subscribers, hand control to the caller's block to trigger
+# publishing (inline or via cross-process signal), then wait for delivery
+# and report. Reported elapsed = max(receive_ns) - min(publish_ns) so the
+# warmup, cross-process startup lag, and tail polling are excluded.
+def measure(label, opts, pubsub, deadline_s:)
+  target = opts[:subscribers] * opts[:rounds]
+  received = 0
+  latencies = []
+  first_publish_ns = nil
+  last_receive_ns = nil
+
+  Sync do |task|
+    pubsub.start(task)
+
+    channels = opts[:subscribers].times.map { |i| pubsub.subscribe("bench.#{i}") }
+    consumers = channels.map do |ch|
+      task.async do
+        ch.start do |m, _|
+          now = now_ns
+          received += 1
+          publish_ns = m.payload.publish_ns
+          first_publish_ns = publish_ns if first_publish_ns.nil? || publish_ns < first_publish_ns
+          last_receive_ns = now
+          latencies << (now - publish_ns)
+        end
+      end
+    end
+
+    sleep 0.1 # let subscriptions settle (broker has accepted the local peer)
+
+    yield task
+
+    deadline = now_s + deadline_s
+    sleep(0.005) until received >= target || now_s > deadline
+
+    channels.each(&:stop)
+    consumers.each(&:wait)
+  end
+
+  elapsed = first_publish_ns && last_receive_ns ? (last_receive_ns - first_publish_ns) / 1e9 : 0
+  report(label, opts, received, elapsed, latencies)
+  warn "  WARN: only #{received}/#{target} messages received before timeout" if received < target
+end
+
+def run_inproc(opts)
+  Dir.mktmpdir(['srl-bench-', ''], '/tmp') do |root|
+    pubsub = build(root)
+    measure('inproc', opts, pubsub, deadline_s: 60) do |_task|
+      publish_round_robin(pubsub, opts)
+    end
+  end
+end
+
+def run_xproc(opts)
+  Dir.mktmpdir(['srl-bench-', ''], '/tmp') do |root|
+    ready_path = File.join(root, 'subs_ready')
+
+    child = fork do
+      pubsub = build(root)
+      Sync do |task|
+        pubsub.start(task)
+        sleep 0.02 until File.exist?(ready_path)
+        sleep 0.1 # let our client connection be accepted by the parent's broker
+        publish_round_robin(pubsub, opts)
+        sleep 0.5 # flush
+        task.stop
+      end
+      exit!(0)
+    end
+
+    pubsub = build(root)
+    measure('xproc', opts, pubsub, deadline_s: 120) do |_task|
+      sleep 0.02 until pubsub.leader? # we forked first → we should win flock
+      File.write(ready_path, '1')
+    end
+
+    Process.kill('TERM', child) rescue nil
+    Process.wait(child)
+  end
+end
+
+case opts[:mode]
+when :inproc then run_inproc(opts)
+when :xproc  then run_xproc(opts)
+end

--- a/lib/sidereal.rb
+++ b/lib/sidereal.rb
@@ -10,6 +10,10 @@ module Sidereal
 
   DispatcherInterface = Types::Interface[:start]
   PubsubInterface = Types::Interface[:start, :subscribe, :publish]
+  # Sidereal apps only append to stores
+  # It's up to dispatcher implementations how to use the store to claim commands
+  # Ex. Sourced's store has a more sophisticated claim mechanism than Sidereal::Store
+  StoreWriterInterface = Types::Interface[:append]
 
   def self.message_method_name(prefix, name)
     "__handle_#{prefix}_#{name.split('::').map(&:downcase).join('_')}"
@@ -30,7 +34,7 @@ module Sidereal
     end
 
     def store=(s)
-      @store = s
+      @store = StoreWriterInterface.parse(s)
     end
 
     def pubsub=(p)

--- a/lib/sidereal.rb
+++ b/lib/sidereal.rb
@@ -9,6 +9,7 @@ module Sidereal
   # Your code goes here...
 
   DispatcherInterface = Types::Interface[:start]
+  PubsubInterface = Types::Interface[:start, :subscribe, :publish]
 
   def self.message_method_name(prefix, name)
     "__handle_#{prefix}_#{name.split('::').map(&:downcase).join('_')}"
@@ -19,26 +20,25 @@ module Sidereal
 
   class Configuration
     attr_accessor :workers
-    attr_writer :store, :pubsub
+    attr_reader :store, :pubsub, :dispatcher
 
     def initialize(workers: 25)
       @workers = workers
+      @pubsub = PubSub::Memory.instance
+      @store = Store::Memory.instance
+      @dispatcher = Sidereal::Dispatcher
     end
 
-    def store
-      @store || Store::Memory.instance
+    def store=(s)
+      @store = s
     end
 
-    def pubsub
-      @pubsub || PubSub::Memory.instance
+    def pubsub=(p)
+      @pubsub = PubsubInterface.parse(p)
     end
 
     def dispatcher=(d)
       @dispatcher = DispatcherInterface.parse(d)
-    end
-
-    def dispatcher
-      @dispatcher || Dispatcher
     end
   end
 

--- a/lib/sidereal.rb
+++ b/lib/sidereal.rb
@@ -2,10 +2,13 @@
 
 require 'async'
 require_relative 'sidereal/version'
+require_relative 'sidereal/types'
 
 module Sidereal
   class Error < StandardError; end
   # Your code goes here...
+
+  DispatcherInterface = Types::Interface[:start]
 
   def self.message_method_name(prefix, name)
     "__handle_#{prefix}_#{name.split('::').map(&:downcase).join('_')}"
@@ -16,7 +19,7 @@ module Sidereal
 
   class Configuration
     attr_accessor :workers
-    attr_writer :store, :pubsub, :dispatcher
+    attr_writer :store, :pubsub
 
     def initialize(workers: 25)
       @workers = workers
@@ -28,6 +31,10 @@ module Sidereal
 
     def pubsub
       @pubsub || PubSub::Memory.instance
+    end
+
+    def dispatcher=(d)
+      @dispatcher = DispatcherInterface.parse(d)
     end
 
     def dispatcher
@@ -107,7 +114,6 @@ module Sidereal
   end
 end
 
-require_relative 'sidereal/types'
 require_relative 'sidereal/message'
 require_relative 'sidereal/router'
 require_relative 'sidereal/components/layout'

--- a/lib/sidereal/dispatcher.rb
+++ b/lib/sidereal/dispatcher.rb
@@ -27,10 +27,6 @@ module Sidereal
 
     def spawn_into(task)
       @store.start(task)
-      # Spawn pubsub from the dispatcher's long-lived task so its background
-      # fibers (broker, client read loop) outlive any short-lived per-request
-      # fiber that might happen to be the first to subscribe or publish.
-      @pubsub.start(task)
 
       @worker_count.times do
         task.async do

--- a/lib/sidereal/dispatcher.rb
+++ b/lib/sidereal/dispatcher.rb
@@ -27,6 +27,10 @@ module Sidereal
 
     def spawn_into(task)
       @store.start(task)
+      # Spawn pubsub from the dispatcher's long-lived task so its background
+      # fibers (broker, client read loop) outlive any short-lived per-request
+      # fiber that might happen to be the first to subscribe or publish.
+      @pubsub.start(task)
 
       @worker_count.times do
         task.async do

--- a/lib/sidereal/dispatcher.rb
+++ b/lib/sidereal/dispatcher.rb
@@ -4,13 +4,13 @@ require 'async'
 
 module Sidereal
   class Dispatcher
-    def self.spawn_into(task)
+    def self.start(task)
       new(
         worker_count: Sidereal.config.workers,
         store: Sidereal.store,
         registry: Sidereal.registry,
         pubsub: Sidereal.pubsub
-      ).spawn_into(task)
+      ).start(task)
     end
 
     def initialize(
@@ -25,7 +25,7 @@ module Sidereal
       @pubsub = pubsub
     end
 
-    def spawn_into(task)
+    def start(task)
       @store.start(task)
 
       @worker_count.times do

--- a/lib/sidereal/falcon/environment.rb
+++ b/lib/sidereal/falcon/environment.rb
@@ -48,7 +48,7 @@ module Sidereal
             # also benefits from the long-lived Falcon task as the parent for
             # pubsub's background fibers.
             Sidereal.pubsub.start(task)
-            @dispatcher = Sidereal.dispatcher.spawn_into(task)
+            @dispatcher = Sidereal.dispatcher.start(task)
 
             task.children.each(&:wait)
           end

--- a/lib/sidereal/falcon/environment.rb
+++ b/lib/sidereal/falcon/environment.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'falcon/environment/server'
+require 'falcon/environment/rackup'
+require 'falcon/service/server'
 require 'sidereal/dispatcher'
 
 module Sidereal

--- a/lib/sidereal/falcon/environment.rb
+++ b/lib/sidereal/falcon/environment.rb
@@ -42,6 +42,12 @@ module Sidereal
 
           Async do |task|
             server.run
+            # Start the configured pubsub here (not inside the dispatcher)
+            # so it works regardless of which dispatcher implementation is
+            # plugged in — e.g. Sourced's Dispatcher in examples/sourced_donations
+            # also benefits from the long-lived Falcon task as the parent for
+            # pubsub's background fibers.
+            Sidereal.pubsub.start(task)
             @dispatcher = Sidereal.dispatcher.spawn_into(task)
 
             task.children.each(&:wait)

--- a/lib/sidereal/pubsub/memory.rb
+++ b/lib/sidereal/pubsub/memory.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'singleton'
+require_relative 'pattern'
 
 module Sidereal
   module PubSub
@@ -8,17 +9,11 @@ module Sidereal
     # Thread/fiber-safe. Each subscriber gets its own queue,
     # so a slow consumer won't block other subscribers.
     #
-    # Supports NATS-style wildcard subscriptions:
-    #   `*` matches exactly one non-empty segment
-    #       (e.g. "donations.*" matches "donations.111" but not "donations.111.created")
-    #   `>` matches one or more non-empty segments; must be the trailing token
-    #       (e.g. "donations.>" matches "donations.111" and "donations.222.created")
+    # See {Pattern} for the wildcard subscription rules.
     class Memory
       include Singleton
 
       public_class_method :new
-
-      SEGMENT_SEPARATOR = '.'
 
       def initialize
         @mutex = Mutex.new
@@ -26,14 +21,21 @@ module Sidereal
         @wildcards = []
       end
 
+      # Lifecycle hook. {Memory} has no background work, so this is a no-op
+      # that exists to keep the contract uniform with backends that do
+      # (e.g. {Sidereal::PubSub::Unix}).
+      def start(_task)
+        self
+      end
+
       # @param pattern [String] exact channel name or wildcard pattern
       # @return [Channel]
       def subscribe(pattern)
-        validate_subscription!(pattern)
+        Pattern.validate_subscription!(pattern)
         channel = Channel.new(name: pattern, pubsub: self)
         @mutex.synchronize do
-          if wildcard?(pattern)
-            @wildcards = @wildcards + [[compile(pattern), channel]]
+          if Pattern.wildcard?(pattern)
+            @wildcards = @wildcards + [[Pattern.compile(pattern), channel]]
           else
             @subscribers[pattern] = (@subscribers[pattern] || []) + [channel]
           end
@@ -45,7 +47,7 @@ module Sidereal
       # @param channel [Channel]
       def unsubscribe(channel)
         @mutex.synchronize do
-          if wildcard?(channel.name)
+          if Pattern.wildcard?(channel.name)
             @wildcards = @wildcards.reject { |_re, ch| ch.equal?(channel) }
           else
             arr = @subscribers[channel.name]
@@ -55,10 +57,10 @@ module Sidereal
       end
 
       # @param channel_name [String] concrete channel name (no wildcards)
-      # @param event [Sourced::Message]
+      # @param event [Sidereal::Message]
       # @return [self]
       def publish(channel_name, event)
-        validate_publish!(channel_name)
+        Pattern.validate_publish!(channel_name)
         targets = @mutex.synchronize do
           list = []
           list.concat(@subscribers[channel_name]) if @subscribers[channel_name]
@@ -67,52 +69,6 @@ module Sidereal
         end
         targets.each { |ch| ch << event }
         self
-      end
-
-      private
-
-      def wildcard?(name)
-        name.split(SEGMENT_SEPARATOR, -1).any? { |seg| seg == '*' || seg == '>' }
-      end
-
-      def validate_subscription!(pattern)
-        raise ArgumentError, 'channel pattern must not be empty' if pattern.empty?
-
-        segments = pattern.split(SEGMENT_SEPARATOR, -1)
-        if segments.any?(&:empty?)
-          raise ArgumentError, "empty segment in channel pattern #{pattern.inspect}"
-        end
-
-        segments.each_with_index do |seg, i|
-          if seg == '>' && i != segments.size - 1
-            raise ArgumentError,
-                  "`>` wildcard must be the last segment in #{pattern.inspect}"
-          end
-        end
-      end
-
-      def validate_publish!(channel_name)
-        raise ArgumentError, 'channel name must not be empty' if channel_name.empty?
-
-        segments = channel_name.split(SEGMENT_SEPARATOR, -1)
-        if segments.any?(&:empty?)
-          raise ArgumentError, "empty segment in channel name #{channel_name.inspect}"
-        end
-        if segments.any? { |s| s == '*' || s == '>' }
-          raise ArgumentError,
-                "wildcards are not allowed when publishing: #{channel_name.inspect}"
-        end
-      end
-
-      def compile(pattern)
-        parts = pattern.split(SEGMENT_SEPARATOR).map do |seg|
-          case seg
-          when '*' then '[^.]+'
-          when '>' then '.+'
-          else Regexp.escape(seg)
-          end
-        end
-        Regexp.new('\A' + parts.join('\.') + '\z')
       end
 
       class Channel
@@ -125,7 +81,7 @@ module Sidereal
         end
 
         # Push a message into this channel's queue.
-        # @param message [Sourced::Message]
+        # @param message [Sidereal::Message]
         # @return [self]
         def <<(message)
           @queue << message
@@ -134,7 +90,7 @@ module Sidereal
 
         # Block and process messages from the queue.
         # @param handler [#call, nil]
-        # @yieldparam message [Sourced::Message]
+        # @yieldparam message [Sidereal::Message]
         # @yieldparam channel [Channel]
         # @return [self]
         def start(handler: nil, &block)

--- a/lib/sidereal/pubsub/memory.rb
+++ b/lib/sidereal/pubsub/memory.rb
@@ -35,9 +35,9 @@ module Sidereal
         channel = Channel.new(name: pattern, pubsub: self)
         @mutex.synchronize do
           if Pattern.wildcard?(pattern)
-            @wildcards = @wildcards + [[Pattern.compile(pattern), channel]]
+            @wildcards << [Pattern.compile(pattern), channel]
           else
-            @subscribers[pattern] = (@subscribers[pattern] || []) + [channel]
+            (@subscribers[pattern] ||= []) << channel
           end
         end
         channel
@@ -48,10 +48,13 @@ module Sidereal
       def unsubscribe(channel)
         @mutex.synchronize do
           if Pattern.wildcard?(channel.name)
-            @wildcards = @wildcards.reject { |_re, ch| ch.equal?(channel) }
+            @wildcards.reject! { |_re, ch| ch.equal?(channel) }
           else
             arr = @subscribers[channel.name]
-            @subscribers[channel.name] = arr - [channel] if arr
+            next unless arr
+
+            arr.delete(channel)
+            @subscribers.delete(channel.name) if arr.empty?
           end
         end
       end
@@ -62,12 +65,16 @@ module Sidereal
       def publish(channel_name, event)
         Pattern.validate_publish!(channel_name)
         targets = @mutex.synchronize do
-          list = []
-          list.concat(@subscribers[channel_name]) if @subscribers[channel_name]
-          @wildcards.each { |re, ch| list << ch if re.match?(channel_name) }
-          list
+          exact = @subscribers[channel_name]
+          if @wildcards.empty?
+            exact && exact.dup
+          else
+            list = exact ? exact.dup : []
+            @wildcards.each { |re, ch| list << ch if re.match?(channel_name) }
+            list.empty? ? nil : list
+          end
         end
-        targets.each { |ch| ch << event }
+        targets&.each { |ch| ch << event }
         self
       end
 

--- a/lib/sidereal/pubsub/pattern.rb
+++ b/lib/sidereal/pubsub/pattern.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Sidereal
+  module PubSub
+    # NATS-style channel pattern matching, shared by every PubSub backend.
+    #
+    #   `*` matches exactly one non-empty segment
+    #       ("donations.*" matches "donations.111" but not "donations.111.created")
+    #   `>` matches one or more non-empty segments; must be the trailing token
+    #       ("donations.>" matches "donations.111" and "donations.222.created")
+    #
+    # All methods are pure — call them as +Pattern.wildcard?(name)+ etc.
+    module Pattern
+      SEGMENT_SEPARATOR = '.'
+
+      # @param name [String]
+      # @return [Boolean]
+      def self.wildcard?(name)
+        name.split(SEGMENT_SEPARATOR, -1).any? { |seg| seg == '*' || seg == '>' }
+      end
+
+      # Compile a subscription pattern into an anchored Regexp.
+      # @param pattern [String]
+      # @return [Regexp]
+      def self.compile(pattern)
+        parts = pattern.split(SEGMENT_SEPARATOR).map do |seg|
+          case seg
+          when '*' then '[^.]+'
+          when '>' then '.+'
+          else Regexp.escape(seg)
+          end
+        end
+        Regexp.new('\A' + parts.join('\.') + '\z')
+      end
+
+      # @raise [ArgumentError] for empty patterns, empty segments, or non-trailing `>`.
+      def self.validate_subscription!(pattern)
+        raise ArgumentError, 'channel pattern must not be empty' if pattern.empty?
+
+        segments = pattern.split(SEGMENT_SEPARATOR, -1)
+        if segments.any?(&:empty?)
+          raise ArgumentError, "empty segment in channel pattern #{pattern.inspect}"
+        end
+
+        segments.each_with_index do |seg, i|
+          if seg == '>' && i != segments.size - 1
+            raise ArgumentError,
+                  "`>` wildcard must be the last segment in #{pattern.inspect}"
+          end
+        end
+      end
+
+      # @raise [ArgumentError] for empty names, empty segments, or any wildcard token.
+      def self.validate_publish!(channel_name)
+        raise ArgumentError, 'channel name must not be empty' if channel_name.empty?
+
+        segments = channel_name.split(SEGMENT_SEPARATOR, -1)
+        if segments.any?(&:empty?)
+          raise ArgumentError, "empty segment in channel name #{channel_name.inspect}"
+        end
+        if segments.any? { |s| s == '*' || s == '>' }
+          raise ArgumentError,
+                "wildcards are not allowed when publishing: #{channel_name.inspect}"
+        end
+      end
+    end
+  end
+end

--- a/lib/sidereal/pubsub/unix.rb
+++ b/lib/sidereal/pubsub/unix.rb
@@ -69,21 +69,15 @@ module Sidereal
         @started = false
       end
 
-      # Whether this process currently holds the broker role — i.e. has won
-      # the +flock+ election and bound the listening socket. While +true+,
-      # this process is fanning out frames to every connected peer. Flips
-      # back to +false+ when the broker is torn down (clean shutdown or a
-      # detected EOF triggering reconnect).
+      # Whether this process currently holds the broker role.
       # @return [Boolean]
       def leader?
         !@server.nil?
       end
 
-      # Lifecycle hook. Idempotent; safe to call from any caller before any
-      # publish or subscribe. Spawns a single +run_client+ fiber as a
-      # transient child of +task+; that fiber handles election (via
-      # +flock+), broker setup (when elected), and the read loop, with
-      # automatic reconnect on EOF or error.
+      # Idempotent. Spawns the election + read loop as a transient child of
+      # +task+; that fiber handles flock election, broker setup when
+      # elected, and reconnect-with-backoff on EOF or error.
       def start(task)
         @mutex.synchronize do
           return self if @started
@@ -213,10 +207,8 @@ module Sidereal
 
       def encode_frame(channel_name, event)
         attrs = event.to_h
-        attrs.each do |k, v|
-          attrs[k] = v.iso8601(6) if v.is_a?(Time)
-        end
-        JSON.dump(channel: channel_name, msg: attrs) + "\n"
+        attrs.transform_values! { |v| v.is_a?(Time) ? v.iso8601(6) : v }
+        JSON.generate(channel: channel_name, msg: attrs) << "\n"
       end
 
       def decode_frame(line)
@@ -262,7 +254,11 @@ module Sidereal
       def run_one_connection(task)
         if try_become_leader
           # Replace any stale socket from a dead prior leader.
-          File.unlink(@socket_path) if File.exist?(@socket_path)
+          begin
+            File.unlink(@socket_path)
+          rescue Errno::ENOENT
+            # nothing to clean up
+          end
           @server = UNIXServer.new(@socket_path)
           @broker_task = task.async(transient: true) { run_broker(task) }
           Console.info(self, "pubsub: elected as broker", pid: Process.pid, socket: @socket_path)
@@ -274,8 +270,7 @@ module Sidereal
 
         @client_socket.each_line do |line|
           begin
-            channel_name, event = decode_frame(line)
-            deliver_local(channel_name, event) if channel_name && event
+            deliver_local(*decode_frame(line))
           rescue StandardError => ex
             Console.error(self, 'pubsub frame decode failed', exception: ex, line: line)
           end
@@ -304,10 +299,10 @@ module Sidereal
           Console.info(self, "pubsub: stepped down as broker", pid: Process.pid)
         end
 
-        @peers_mutex.synchronize do
-          @peers.each_key { |peer| peer.close rescue nil }
-          @peers.clear
-        end
+        # Drain peers via drop_peer so writer fibers blocked on their
+        # write_queue.pop see the nil sentinel and exit cleanly. A bare
+        # @peers.clear would leak those fibers until parent teardown.
+        @peers.keys.each { |peer| drop_peer(peer) }
       end
 
       def rand_backoff
@@ -335,6 +330,8 @@ module Sidereal
           while (line = write_queue.pop)
             peer.write(line)
           end
+        rescue Errno::EPIPE, Errno::ECONNRESET, IOError
+          # peer disconnected — normal
         rescue StandardError => ex
           Console.warn(self, 'broker peer writer failed', exception: ex)
         ensure
@@ -344,6 +341,8 @@ module Sidereal
         # Reader fiber: each_line → fan out to every other peer.
         task.async(transient: true) do
           peer.each_line { |line| fan_out(line, except: peer) }
+        rescue Errno::EPIPE, Errno::ECONNRESET, IOError, EOFError
+          # peer disconnected — normal
         rescue StandardError => ex
           Console.warn(self, 'broker peer reader failed', exception: ex)
         ensure
@@ -352,18 +351,18 @@ module Sidereal
       end
 
       def fan_out(line, except:)
-        slow_peers = []
+        slow_peers = nil
         @peers_mutex.synchronize do
           @peers.each do |peer, queue|
             next if peer.equal?(except)
             if queue.size >= @write_queue_size
-              slow_peers << peer
+              (slow_peers ||= []) << peer
             else
               queue << line
             end
           end
         end
-        slow_peers.each do |peer|
+        slow_peers&.each do |peer|
           Console.warn(self, 'dropping slow peer', peer: peer.inspect)
           drop_peer(peer)
         end

--- a/lib/sidereal/pubsub/unix.rb
+++ b/lib/sidereal/pubsub/unix.rb
@@ -96,9 +96,9 @@ module Sidereal
         channel = Channel.new(name: pattern, pubsub: self)
         @mutex.synchronize do
           if Pattern.wildcard?(pattern)
-            @wildcards = @wildcards + [[Pattern.compile(pattern), channel]]
+            @wildcards << [Pattern.compile(pattern), channel]
           else
-            @subscribers[pattern] = (@subscribers[pattern] || []) + [channel]
+            (@subscribers[pattern] ||= []) << channel
           end
         end
         channel
@@ -110,10 +110,13 @@ module Sidereal
       def unsubscribe(channel)
         @mutex.synchronize do
           if Pattern.wildcard?(channel.name)
-            @wildcards = @wildcards.reject { |_re, ch| ch.equal?(channel) }
+            @wildcards.reject! { |_re, ch| ch.equal?(channel) }
           else
             arr = @subscribers[channel.name]
-            @subscribers[channel.name] = arr - [channel] if arr
+            next unless arr
+
+            arr.delete(channel)
+            @subscribers.delete(channel.name) if arr.empty?
           end
         end
       end
@@ -194,15 +197,24 @@ module Sidereal
         start(task)
       end
 
-      # Local-only fanout. Mirrors {Memory#publish}.
+      # Local-only fanout. Mirrors {Memory#publish}. Collects matching
+      # channels under the lock, then delivers outside it so a subscriber's
+      # handler can safely re-enter the pubsub. Skips the array allocation
+      # entirely on the hot common path: no exact subscribers + no
+      # wildcards (e.g. a publisher process whose subscribers all live
+      # remotely).
       def deliver_local(channel_name, event)
         targets = @mutex.synchronize do
-          list = []
-          list.concat(@subscribers[channel_name]) if @subscribers[channel_name]
-          @wildcards.each { |re, ch| list << ch if re.match?(channel_name) }
-          list
+          exact = @subscribers[channel_name]
+          if @wildcards.empty?
+            exact && exact.dup
+          else
+            list = exact ? exact.dup : []
+            @wildcards.each { |re, ch| list << ch if re.match?(channel_name) }
+            list.empty? ? nil : list
+          end
         end
-        targets.each { |ch| ch << event }
+        targets&.each { |ch| ch << event }
       end
 
       def encode_frame(channel_name, event)

--- a/lib/sidereal/pubsub/unix.rb
+++ b/lib/sidereal/pubsub/unix.rb
@@ -1,0 +1,383 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'json'
+require 'socket'
+require 'console'
+require_relative 'pattern'
+
+module Sidereal
+  module PubSub
+    # Unix-domain-socket pubsub for cross-process delivery on a single host.
+    #
+    # Topology: embedded leader. The first process to acquire a +flock+ on
+    # +lock_path+ binds +socket_path+ and runs an in-process broker fiber
+    # that fans out frames to every connected peer. Other processes
+    # +connect+ as plain clients. When the leader dies, the kernel closes
+    # its listening socket; clients see EOF and re-run election +
+    # connection inside their reconnect-with-backoff loop. +flock+ is
+    # auto-released on process death — no stale-lock cleanup required.
+    #
+    # Wire format: newline-delimited JSON, one frame type:
+    #
+    #   {"channel": "<name>", "msg": <Message#to_h with iso8601 Times>}\n
+    #
+    # Wildcard matching is performed on the receiving client (the broker
+    # is a dumb fan-out). Failover therefore requires no re-subscription —
+    # the broker holds zero per-client state.
+    #
+    # Public contract is identical to {PubSub::Memory}.
+    class Unix
+      DEFAULT_SOCKET = 'tmp/sidereal-pubsub.sock'
+      DEFAULT_LOCK   = 'tmp/sidereal-pubsub.lock'
+      DEFAULT_WRITE_QUEUE = 1_000
+
+      # macOS sockaddr_un.sun_path is 104 bytes; Linux is 108. Use the smaller.
+      SOCKET_PATH_MAX = 104
+
+      def initialize(
+        socket_path: DEFAULT_SOCKET,
+        lock_path: DEFAULT_LOCK,
+        reconnect_min: 0.05,
+        reconnect_max: 0.5,
+        write_queue_size: DEFAULT_WRITE_QUEUE
+      )
+        @socket_path = File.expand_path(socket_path)
+        @lock_path = File.expand_path(lock_path)
+        validate_socket_path!(@socket_path)
+
+        @reconnect_min = reconnect_min
+        @reconnect_max = reconnect_max
+        @write_queue_size = write_queue_size
+
+        FileUtils.mkdir_p(File.dirname(@socket_path))
+        FileUtils.mkdir_p(File.dirname(@lock_path))
+
+        @mutex = Mutex.new
+        @subscribers = {}
+        @wildcards = []
+
+        @peers_mutex = Mutex.new
+        @peers = {}
+
+        @send_mutex = Mutex.new
+        @client_socket = nil
+        @leader_lock_io = nil
+        @server = nil
+        @broker_task = nil
+
+        @started = false
+      end
+
+      # Whether this process currently holds the broker role — i.e. has won
+      # the +flock+ election and bound the listening socket. While +true+,
+      # this process is fanning out frames to every connected peer. Flips
+      # back to +false+ when the broker is torn down (clean shutdown or a
+      # detected EOF triggering reconnect).
+      # @return [Boolean]
+      def leader?
+        !@server.nil?
+      end
+
+      # Lifecycle hook. Idempotent; safe to call from any caller before any
+      # publish or subscribe. Spawns a single +run_client+ fiber as a
+      # transient child of +task+; that fiber handles election (via
+      # +flock+), broker setup (when elected), and the read loop, with
+      # automatic reconnect on EOF or error.
+      def start(task)
+        @mutex.synchronize do
+          return self if @started
+          @started = true
+        end
+
+        task.async(transient: true) { run_client(task) }
+        self
+      end
+
+      # @param pattern [String] exact channel name or wildcard pattern
+      # @return [Channel]
+      def subscribe(pattern)
+        Pattern.validate_subscription!(pattern)
+        ensure_started
+        channel = Channel.new(name: pattern, pubsub: self)
+        @mutex.synchronize do
+          if Pattern.wildcard?(pattern)
+            @wildcards = @wildcards + [[Pattern.compile(pattern), channel]]
+          else
+            @subscribers[pattern] = (@subscribers[pattern] || []) + [channel]
+          end
+        end
+        channel
+      end
+
+      # Remove a channel from the subscriber list. Local-only — the broker
+      # holds no subscription state.
+      # @param channel [Channel]
+      def unsubscribe(channel)
+        @mutex.synchronize do
+          if Pattern.wildcard?(channel.name)
+            @wildcards = @wildcards.reject { |_re, ch| ch.equal?(channel) }
+          else
+            arr = @subscribers[channel.name]
+            @subscribers[channel.name] = arr - [channel] if arr
+          end
+        end
+      end
+
+      # Deliver synchronously to local subscribers, then write the frame
+      # to the leader's broker. The broker fans out to every other
+      # connected peer (excluding the originator, which already received
+      # the message via the local path). If we're disconnected from the
+      # broker — e.g. mid-failover — the wire publish is dropped with a
+      # warning; local subscribers still receive their copy.
+      #
+      # @param channel_name [String]
+      # @param event [Sidereal::Message]
+      # @return [self]
+      def publish(channel_name, event)
+        Pattern.validate_publish!(channel_name)
+        ensure_started
+
+        deliver_local(channel_name, event)
+
+        frame = encode_frame(channel_name, event)
+        @send_mutex.synchronize do
+          socket = @client_socket
+          if socket
+            begin
+              socket.write(frame)
+            rescue Errno::EPIPE, Errno::ECONNRESET, IOError => ex
+              Console.warn(self, 'publish dropped: socket disconnected', exception: ex)
+            end
+          end
+        end
+
+        self
+      end
+
+      class Channel
+        attr_reader :name
+
+        def initialize(name:, pubsub:)
+          @name = name
+          @pubsub = pubsub
+          @queue = Async::Queue.new
+        end
+
+        def <<(message)
+          @queue << message
+          self
+        end
+
+        def start(handler: nil, &block)
+          handler ||= block
+          while (msg = @queue.pop)
+            handler.call(msg, self)
+          end
+          self
+        end
+
+        def stop
+          @pubsub.unsubscribe(self)
+          @queue << nil
+          self
+        end
+      end
+
+      private
+
+      def ensure_started
+        return if @started
+
+        task = Async::Task.current?
+        return unless task
+
+        # Walk up to the topmost (root) task so the run_client fiber outlives
+        # any short-lived per-request ancestor (e.g. an SSE handler fiber).
+        # Async::Task#parent returns nil at the root.
+        task = task.parent while task.parent
+
+        start(task)
+      end
+
+      # Local-only fanout. Mirrors {Memory#publish}.
+      def deliver_local(channel_name, event)
+        targets = @mutex.synchronize do
+          list = []
+          list.concat(@subscribers[channel_name]) if @subscribers[channel_name]
+          @wildcards.each { |re, ch| list << ch if re.match?(channel_name) }
+          list
+        end
+        targets.each { |ch| ch << event }
+      end
+
+      def encode_frame(channel_name, event)
+        attrs = event.to_h
+        attrs.each do |k, v|
+          attrs[k] = v.iso8601(6) if v.is_a?(Time)
+        end
+        JSON.dump(channel: channel_name, msg: attrs) + "\n"
+      end
+
+      def decode_frame(line)
+        parsed = JSON.parse(line, symbolize_names: true)
+        [parsed[:channel], Sidereal::Message.from(parsed[:msg])]
+      end
+
+      def validate_socket_path!(path)
+        if path.bytesize >= SOCKET_PATH_MAX
+          raise ArgumentError,
+                "socket path is too long (#{path.bytesize} bytes; max #{SOCKET_PATH_MAX - 1}): #{path.inspect}"
+        end
+      end
+
+      # Try to acquire the leader flock. On success, store the open file
+      # in @leader_lock_io (closing it releases the lock).
+      # @return [Boolean]
+      def try_become_leader
+        io = File.open(@lock_path, File::RDWR | File::CREAT, 0o644)
+        if io.flock(File::LOCK_EX | File::LOCK_NB)
+          @leader_lock_io = io
+          true
+        else
+          io.close
+          false
+        end
+      end
+
+      # Combined election + connection + read loop with reconnect-with-
+      # backoff. Every iteration re-runs election: when the prior leader
+      # dies, every connected client lands here and races for flock.
+      def run_client(task)
+        loop do
+          run_one_connection(task)
+        rescue StandardError => ex
+          Console.warn(self, 'pubsub client iteration error', exception: ex)
+        ensure
+          tear_down_connection
+          sleep(rand_backoff)
+        end
+      end
+
+      def run_one_connection(task)
+        if try_become_leader
+          # Replace any stale socket from a dead prior leader.
+          File.unlink(@socket_path) if File.exist?(@socket_path)
+          @server = UNIXServer.new(@socket_path)
+          @broker_task = task.async(transient: true) { run_broker(task) }
+          Console.info(self, "pubsub: elected as broker", pid: Process.pid, socket: @socket_path)
+        else
+          Console.info(self, "pubsub: connecting as client", pid: Process.pid, socket: @socket_path)
+        end
+
+        @client_socket = UNIXSocket.new(@socket_path)
+
+        @client_socket.each_line do |line|
+          begin
+            channel_name, event = decode_frame(line)
+            deliver_local(channel_name, event) if channel_name && event
+          rescue StandardError => ex
+            Console.error(self, 'pubsub frame decode failed', exception: ex, line: line)
+          end
+        end
+      end
+
+      def tear_down_connection
+        if (sock = @client_socket)
+          @client_socket = nil
+          sock.close rescue nil
+        end
+
+        if (broker = @broker_task)
+          @broker_task = nil
+          broker.stop
+        end
+
+        if (srv = @server)
+          @server = nil
+          srv.close rescue nil
+        end
+
+        if (lock = @leader_lock_io)
+          @leader_lock_io = nil
+          lock.close rescue nil
+          Console.info(self, "pubsub: stepped down as broker", pid: Process.pid)
+        end
+
+        @peers_mutex.synchronize do
+          @peers.each_key { |peer| peer.close rescue nil }
+          @peers.clear
+        end
+      end
+
+      def rand_backoff
+        @reconnect_min + (rand * (@reconnect_max - @reconnect_min))
+      end
+
+      # Broker (leader-only) accept loop. Each peer gets a writer fiber
+      # draining a per-peer LimitedQueue and a reader fiber that fans
+      # received frames out to every other peer.
+      def run_broker(task)
+        loop do
+          peer = @server.accept
+          register_peer(task, peer)
+        end
+      rescue IOError, Errno::EBADF
+        # Server closed — leader is shutting down; exit cleanly.
+      end
+
+      def register_peer(task, peer)
+        write_queue = Async::LimitedQueue.new(@write_queue_size)
+        @peers_mutex.synchronize { @peers[peer] = write_queue }
+
+        # Writer fiber: drain queue → write to peer.
+        task.async(transient: true) do
+          while (line = write_queue.pop)
+            peer.write(line)
+          end
+        rescue StandardError => ex
+          Console.warn(self, 'broker peer writer failed', exception: ex)
+        ensure
+          drop_peer(peer)
+        end
+
+        # Reader fiber: each_line → fan out to every other peer.
+        task.async(transient: true) do
+          peer.each_line { |line| fan_out(line, except: peer) }
+        rescue StandardError => ex
+          Console.warn(self, 'broker peer reader failed', exception: ex)
+        ensure
+          drop_peer(peer)
+        end
+      end
+
+      def fan_out(line, except:)
+        slow_peers = []
+        @peers_mutex.synchronize do
+          @peers.each do |peer, queue|
+            next if peer.equal?(except)
+            if queue.size >= @write_queue_size
+              slow_peers << peer
+            else
+              queue << line
+            end
+          end
+        end
+        slow_peers.each do |peer|
+          Console.warn(self, 'dropping slow peer', peer: peer.inspect)
+          drop_peer(peer)
+        end
+      end
+
+      def drop_peer(peer)
+        queue = nil
+        @peers_mutex.synchronize do
+          queue = @peers.delete(peer)
+        end
+        # Unblock the writer fiber if it's waiting.
+        queue << nil if queue
+        peer.close rescue nil
+      end
+    end
+  end
+end

--- a/spec/dispatcher_spec.rb
+++ b/spec/dispatcher_spec.rb
@@ -249,7 +249,6 @@ RSpec.describe Sidereal::Dispatcher do
       real_pubsub.publish(channel, msg)
     end
     flaky_pubsub.define_singleton_method(:subscribe) { |c| real_pubsub.subscribe(c) }
-    flaky_pubsub.define_singleton_method(:start) { |_t| flaky_pubsub }
 
     handled_titles = []
     cmdr = Class.new(Sidereal::Commander) do

--- a/spec/dispatcher_spec.rb
+++ b/spec/dispatcher_spec.rb
@@ -249,6 +249,7 @@ RSpec.describe Sidereal::Dispatcher do
       real_pubsub.publish(channel, msg)
     end
     flaky_pubsub.define_singleton_method(:subscribe) { |c| real_pubsub.subscribe(c) }
+    flaky_pubsub.define_singleton_method(:start) { |_t| flaky_pubsub }
 
     handled_titles = []
     cmdr = Class.new(Sidereal::Commander) do

--- a/spec/dispatcher_spec.rb
+++ b/spec/dispatcher_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Sidereal::Dispatcher do
         store: store,
         registry: registry,
         pubsub: pubsub
-      ).spawn_into(task)
+      ).start(task)
 
       task.async do
         block.call if block
@@ -202,7 +202,7 @@ RSpec.describe Sidereal::Dispatcher do
 
       Sidereal::Dispatcher.new(
         worker_count: 1, store: store, registry: registry_for(routing_commander), pubsub: pubsub
-      ).spawn_into(task)
+      ).start(task)
 
       task.async do
         sleep 0.05

--- a/spec/pubsub/pattern_spec.rb
+++ b/spec/pubsub/pattern_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Sidereal::PubSub::Pattern do
+  describe '.wildcard?' do
+    it 'is true for `*` segments' do
+      expect(described_class.wildcard?('donations.*')).to be true
+    end
+
+    it 'is true for `>` segments' do
+      expect(described_class.wildcard?('donations.>')).to be true
+    end
+
+    it 'is false for plain names' do
+      expect(described_class.wildcard?('donations.111')).to be false
+    end
+
+    it 'is false for the empty string' do
+      expect(described_class.wildcard?('')).to be false
+    end
+  end
+
+  describe '.compile' do
+    it 'matches exact channel names' do
+      re = described_class.compile('donations.111')
+      expect(re.match?('donations.111')).to be true
+      expect(re.match?('donations.222')).to be false
+    end
+
+    it 'compiles `*` to one non-empty segment' do
+      re = described_class.compile('donations.*')
+      expect(re.match?('donations.111')).to be true
+      expect(re.match?('donations.111.created')).to be false
+      expect(re.match?('donations.')).to be false
+    end
+
+    it 'compiles `>` to one or more segments' do
+      re = described_class.compile('donations.>')
+      expect(re.match?('donations.111')).to be true
+      expect(re.match?('donations.111.created')).to be true
+      expect(re.match?('donations')).to be false
+    end
+
+    it 'compiles a bare `>` to "everything"' do
+      re = described_class.compile('>')
+      expect(re.match?('a')).to be true
+      expect(re.match?('a.b.c')).to be true
+    end
+
+    it 'escapes regex metacharacters in plain segments' do
+      re = described_class.compile('a.b+c.d')
+      expect(re.match?('a.b+c.d')).to be true
+      expect(re.match?('a.bc.d')).to be false
+    end
+  end
+
+  describe '.validate_subscription!' do
+    it 'rejects empty pattern' do
+      expect { described_class.validate_subscription!('') }.to raise_error(ArgumentError)
+    end
+
+    it 'rejects empty segments' do
+      expect { described_class.validate_subscription!('a..b') }
+        .to raise_error(ArgumentError, /empty segment/)
+      expect { described_class.validate_subscription!('a.') }
+        .to raise_error(ArgumentError, /empty segment/)
+      expect { described_class.validate_subscription!('.a') }
+        .to raise_error(ArgumentError, /empty segment/)
+    end
+
+    it 'rejects `>` in non-trailing position' do
+      expect { described_class.validate_subscription!('a.>.c') }
+        .to raise_error(ArgumentError, /must be the last segment/)
+    end
+
+    it 'allows `>` as the last segment' do
+      expect { described_class.validate_subscription!('a.>') }.not_to raise_error
+    end
+
+    it 'allows `>` as the only segment' do
+      expect { described_class.validate_subscription!('>') }.not_to raise_error
+    end
+  end
+
+  describe '.validate_publish!' do
+    it 'rejects empty channel name' do
+      expect { described_class.validate_publish!('') }.to raise_error(ArgumentError)
+    end
+
+    it 'rejects empty segments' do
+      expect { described_class.validate_publish!('a..b') }
+        .to raise_error(ArgumentError, /empty segment/)
+    end
+
+    it 'rejects `*` wildcards' do
+      expect { described_class.validate_publish!('a.*') }
+        .to raise_error(ArgumentError, /wildcards are not allowed/)
+    end
+
+    it 'rejects `>` wildcards' do
+      expect { described_class.validate_publish!('a.>') }
+        .to raise_error(ArgumentError, /wildcards are not allowed/)
+    end
+  end
+end

--- a/spec/pubsub/unix_failover_spec.rb
+++ b/spec/pubsub/unix_failover_spec.rb
@@ -1,0 +1,205 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'async'
+require 'tmpdir'
+require 'json'
+require 'sidereal/pubsub/unix'
+
+UnixFailoverMsg = Sidereal::Message.define('unix_failover_spec.event') do
+  attribute :tag, Sidereal::Types::String
+end
+
+RSpec.describe 'Sidereal::PubSub::Unix cross-process' do
+  around(:each) do |example|
+    # Use /tmp directly so socket paths fit inside the 104-byte sun_path limit
+    # (macOS's default tmpdir under /var/folders/... is too long).
+    Dir.mktmpdir(['srl-', ''], '/tmp') do |root|
+      @root = root
+      example.run
+    end
+  end
+
+  def socket_path = File.join(@root, 'pubsub.sock')
+  def lock_path = File.join(@root, 'pubsub.lock')
+
+  def build_pubsub
+    Sidereal::PubSub::Unix.new(
+      socket_path: socket_path,
+      lock_path: lock_path,
+      reconnect_min: 0.02,
+      reconnect_max: 0.05
+    )
+  end
+
+  describe 'fan-out across two processes' do
+    it 'delivers messages from a publisher to a subscriber in another process' do
+      received_path = File.join(@root, 'received.json')
+      ready_path = File.join(@root, 'subscriber_ready')
+
+      child_pid = fork do
+        # Child: become leader (run first), subscribe, collect a few messages.
+        pubsub = build_pubsub
+        received = []
+        Sync do |task|
+          pubsub.start(task)
+          channel = pubsub.subscribe('events.>')
+          collector = task.async do
+            channel.start { |m, _| received << m.payload.tag }
+          end
+
+          # Wait until our broker is up before signalling readiness.
+          sleep 0.05 until pubsub.leader?
+          File.write(ready_path, '1')
+
+          deadline = Time.now + 3.0
+          sleep 0.02 until received.size >= 3 || Time.now > deadline
+          channel.stop
+          collector.wait
+        end
+        File.write(received_path, JSON.dump(received))
+        exit!(0)
+      end
+
+      # Parent: wait for the child's broker to bind, then connect and publish.
+      deadline = Time.now + 3.0
+      sleep 0.02 until File.exist?(ready_path) || Time.now > deadline
+      raise 'child subscriber never signalled ready' unless File.exist?(ready_path)
+
+      pubsub = build_pubsub
+      Sync do |task|
+        pubsub.start(task)
+        # Allow a moment for the client connection to be accepted by the broker.
+        sleep 0.1
+        3.times { |i| pubsub.publish("events.#{i}", UnixFailoverMsg.new(payload: { tag: i.to_s })) }
+        # Allow time for frames to traverse the wire before exiting Sync.
+        sleep 0.3
+        task.stop
+      end
+
+      Process.wait(child_pid)
+      received = JSON.parse(File.read(received_path))
+      expect(received.sort).to eq(%w[0 1 2])
+    end
+  end
+
+  describe 'leader election across three processes' do
+    it 'elects exactly one leader' do
+      results_dir = File.join(@root, 'leadership')
+      FileUtils.mkdir_p(results_dir)
+
+      pids = 3.times.map do |i|
+        fork do
+          pubsub = build_pubsub
+          Sync do |task|
+            pubsub.start(task)
+            sleep 0.3 # let election settle
+            File.write(File.join(results_dir, "#{i}.txt"), pubsub.leader?.to_s)
+            task.stop
+          end
+          exit!(0)
+        end
+      end
+
+      pids.each { |pid| Process.wait(pid) }
+
+      results = Dir.children(results_dir).map { |f| File.read(File.join(results_dir, f)) }
+      expect(results.count('true')).to eq(1)
+      expect(results.count('false')).to eq(2)
+    end
+  end
+
+  describe 'failover when the leader dies' do
+    it 'promotes a survivor and resumes message flow' do
+      # Process A: becomes leader, then SIGKILL'd by the parent.
+      # Process B: starts as client, takes over leadership, subscribes,
+      #            collects post-failover messages.
+      received_path = File.join(@root, 'received.json')
+      b_ready_path = File.join(@root, 'b_ready')
+
+      a_pid = fork do
+        pubsub = build_pubsub
+        Sync do |task|
+          pubsub.start(task)
+          # Hold the leadership until killed.
+          sleep
+        end
+        exit!(0)
+      end
+
+      # Wait for A to become leader.
+      deadline = Time.now + 3.0
+      sleep 0.02 until File.exist?(socket_path) || Time.now > deadline
+      raise 'leader A never bound socket' unless File.exist?(socket_path)
+      sleep 0.1 # let A's accept loop settle
+
+      b_pid = fork do
+        pubsub = build_pubsub
+        received = []
+        Sync do |task|
+          pubsub.start(task)
+          channel = pubsub.subscribe('after.>')
+          collector = task.async do
+            channel.start { |m, _| received << m.payload.tag }
+          end
+
+          # Wait until B has become leader (i.e. A has died and B has been promoted).
+          sleep 0.05 until pubsub.leader?
+          File.write(b_ready_path, '1')
+
+          deadline = Time.now + 3.0
+          sleep 0.02 until received.size >= 2 || Time.now > deadline
+          channel.stop
+          collector.wait
+        end
+        File.write(received_path, JSON.dump(received))
+        exit!(0)
+      end
+
+      # Give B a moment to connect to A before killing A.
+      sleep 0.3
+      Process.kill('KILL', a_pid)
+      Process.wait(a_pid)
+
+      # Wait for B to have been promoted to leader.
+      deadline = Time.now + 5.0
+      sleep 0.05 until File.exist?(b_ready_path) || Time.now > deadline
+      raise 'B never took over leadership' unless File.exist?(b_ready_path)
+
+      # Publish from a third (fresh) process now that B is leader.
+      publisher_pid = fork do
+        pubsub = build_pubsub
+        Sync do |task|
+          pubsub.start(task)
+          sleep 0.2 # let connection establish
+          2.times { |i| pubsub.publish("after.#{i}", UnixFailoverMsg.new(payload: { tag: i.to_s })) }
+          sleep 0.3
+          task.stop
+        end
+        exit!(0)
+      end
+
+      Process.wait(publisher_pid)
+      Process.wait(b_pid)
+
+      received = JSON.parse(File.read(received_path))
+      expect(received.sort).to eq(%w[0 1])
+    end
+  end
+
+  describe 'publish without a connected broker' do
+    it 'silently drops the wire send and does not raise' do
+      # Outside an Async reactor, ensure_started is a no-op (no current task),
+      # so the pubsub is never started and @client_socket is nil — the same
+      # state a publisher would briefly observe between EOF and reconnect
+      # during a failover. publish must tolerate it.
+      pubsub = Sidereal::PubSub::Unix.new(
+        socket_path: socket_path,
+        lock_path: lock_path
+      )
+      expect do
+        pubsub.publish('any.thing', UnixFailoverMsg.new(payload: { tag: 'lost' }))
+      end.not_to raise_error
+    end
+  end
+end

--- a/spec/pubsub/unix_spec.rb
+++ b/spec/pubsub/unix_spec.rb
@@ -1,0 +1,227 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'async'
+require 'tmpdir'
+require 'sidereal/pubsub/unix'
+
+UnixPubSubMsg = Sidereal::Message.define('unix_pubsub_spec.event') do
+  attribute :tag, Sidereal::Types::String
+end
+
+RSpec.describe Sidereal::PubSub::Unix do
+  around(:each) do |example|
+    # Use /tmp directly so socket paths fit inside the 104-byte sun_path limit
+    # (macOS's default tmpdir under /var/folders/... is too long).
+    Dir.mktmpdir(['srl-', ''], '/tmp') do |root|
+      @root = root
+      example.run
+    end
+  end
+
+  def build_pubsub(**overrides)
+    described_class.new(
+      socket_path: File.join(@root, 'pubsub.sock'),
+      lock_path: File.join(@root, 'pubsub.lock'),
+      reconnect_min: 0.01,
+      reconnect_max: 0.02,
+      **overrides
+    )
+  end
+
+  let(:pubsub) { build_pubsub }
+
+  # Subscribe and start a consumer fiber, then run `body` and stop.
+  # Returns the messages delivered.
+  def collect_from(pattern, body)
+    received = []
+    Sync do |task|
+      pubsub.start(task)
+      channel = pubsub.subscribe(pattern)
+      consumer = task.async { channel.start { |m, _| received << m } }
+      body.call(pubsub)
+      # Allow async fan-out to settle (frame goes over socket → broker → back).
+      sleep 0.05
+      channel.stop
+      consumer.wait
+    end
+    received
+  end
+
+  describe 'exact-match subscription' do
+    it 'delivers messages published to the exact channel name' do
+      evt = UnixPubSubMsg.new(payload: { tag: 'a' })
+      received = collect_from('donations.111', ->(p) { p.publish('donations.111', evt) })
+      expect(received.map { |m| m.payload.tag }).to eq(['a'])
+    end
+
+    it 'does not deliver messages from other channels' do
+      received = collect_from('donations.111', lambda do |p|
+        p.publish('donations.222', UnixPubSubMsg.new(payload: { tag: 'b' }))
+        p.publish('campaigns.x', UnixPubSubMsg.new(payload: { tag: 'c' }))
+      end)
+      expect(received).to be_empty
+    end
+  end
+
+  describe '`*` wildcard subscription' do
+    it 'matches exactly one segment' do
+      received = collect_from('donations.*', lambda do |p|
+        p.publish('donations.111', UnixPubSubMsg.new(payload: { tag: 'a' }))
+        p.publish('donations.222', UnixPubSubMsg.new(payload: { tag: 'b' }))
+      end)
+      expect(received.map { |m| m.payload.tag }).to contain_exactly('a', 'b')
+    end
+
+    it 'does not match deeper paths' do
+      received = collect_from('donations.*', lambda do |p|
+        p.publish('donations.111.created', UnixPubSubMsg.new(payload: { tag: 'a' }))
+      end)
+      expect(received).to be_empty
+    end
+  end
+
+  describe '`>` wildcard subscription' do
+    it 'matches one or more segments' do
+      received = collect_from('donations.>', lambda do |p|
+        p.publish('donations.111', UnixPubSubMsg.new(payload: { tag: 'a' }))
+        p.publish('donations.222.created', UnixPubSubMsg.new(payload: { tag: 'b' }))
+      end)
+      expect(received.map { |m| m.payload.tag }).to contain_exactly('a', 'b')
+    end
+
+    it 'matches everything when used alone' do
+      received = collect_from('>', lambda do |p|
+        p.publish('a.b', UnixPubSubMsg.new(payload: { tag: 'a' }))
+        p.publish('c.d.e', UnixPubSubMsg.new(payload: { tag: 'b' }))
+      end)
+      expect(received.map { |m| m.payload.tag }).to contain_exactly('a', 'b')
+    end
+  end
+
+  describe 'exact + wildcard coexistence' do
+    it 'delivers to both subscribers' do
+      exact_received = []
+      wild_received = []
+      Sync do |task|
+        pubsub.start(task)
+        exact_ch = pubsub.subscribe('donations.111')
+        wild_ch = pubsub.subscribe('donations.*')
+
+        ec = task.async { exact_ch.start { |m, _| exact_received << m } }
+        wc = task.async { wild_ch.start { |m, _| wild_received << m } }
+
+        pubsub.publish('donations.111', UnixPubSubMsg.new(payload: { tag: 'x' }))
+        sleep 0.05
+        exact_ch.stop
+        wild_ch.stop
+        ec.wait
+        wc.wait
+      end
+
+      expect(exact_received.map { |m| m.payload.tag }).to eq(['x'])
+      expect(wild_received.map { |m| m.payload.tag }).to eq(['x'])
+    end
+  end
+
+  describe '#unsubscribe (via Channel#stop)' do
+    it 'removes a subscriber so further publishes skip it' do
+      received = []
+      Sync do |task|
+        pubsub.start(task)
+        channel = pubsub.subscribe('donations.*')
+        consumer = task.async { channel.start { |m, _| received << m } }
+
+        pubsub.publish('donations.111', UnixPubSubMsg.new(payload: { tag: 'before' }))
+        sleep 0.05
+        channel.stop
+        pubsub.publish('donations.222', UnixPubSubMsg.new(payload: { tag: 'after' }))
+        consumer.wait
+      end
+      expect(received.map { |m| m.payload.tag }).to eq(['before'])
+    end
+  end
+
+  describe 'subscription / publish validation' do
+    it 'rejects an empty pattern' do
+      expect { pubsub.subscribe('') }.to raise_error(ArgumentError)
+    end
+
+    it 'rejects publishing with wildcards' do
+      expect { pubsub.publish('a.*', UnixPubSubMsg.new(payload: { tag: 'x' })) }
+        .to raise_error(ArgumentError, /wildcards are not allowed/)
+    end
+  end
+
+  describe 'in-process loopback determinism' do
+    it 'delivers a published message exactly once to a local subscriber' do
+      received = []
+      Sync do |task|
+        pubsub.start(task)
+        channel = pubsub.subscribe('donations.111')
+        consumer = task.async { channel.start { |m, _| received << m } }
+
+        pubsub.publish('donations.111', UnixPubSubMsg.new(payload: { tag: 'once' }))
+        sleep 0.1 # enough for both local + wire paths to settle
+        channel.stop
+        consumer.wait
+      end
+
+      expect(received.size).to eq(1)
+    end
+
+    it 'preserves message id and metadata across the round-trip' do
+      received = nil
+      Sync do |task|
+        pubsub.start(task)
+        channel = pubsub.subscribe('donations.111')
+        consumer = task.async { channel.start { |m, _| received ||= m } }
+
+        original = UnixPubSubMsg.new(payload: { tag: 'roundtrip' }, metadata: { src: 'test' })
+        pubsub.publish('donations.111', original)
+        sleep 0.05
+        channel.stop
+        consumer.wait
+
+        # Local delivery is the synchronous path — `received` is the same instance.
+        expect(received.id).to eq(original.id)
+        expect(received.metadata).to eq(original.metadata)
+      end
+    end
+  end
+
+  describe 'socket path validation' do
+    it 'raises when the socket path is too long' do
+      long_path = File.join(@root, 'a' * 200, 'pubsub.sock')
+      expect do
+        described_class.new(socket_path: long_path, lock_path: File.join(@root, 'pubsub.lock'))
+      end.to raise_error(ArgumentError, /too long/)
+    end
+  end
+
+  describe 'leader election' do
+    it 'lets exactly one of two pubsubs sharing a socket become leader' do
+      a = build_pubsub
+      b = build_pubsub
+
+      a_is_leader = nil
+      b_is_leader = nil
+
+      Sync do |task|
+        a.start(task)
+        # Give A time to acquire flock and bind.
+        sleep 0.1
+        b.start(task)
+        sleep 0.1
+
+        a_is_leader = a.leader?
+        b_is_leader = b.leader?
+
+        # Tear down explicitly to avoid lingering fibers.
+        task.stop
+      end
+
+      expect([a_is_leader, b_is_leader]).to contain_exactly(true, false)
+    end
+  end
+end

--- a/spec/sidereal_spec.rb
+++ b/spec/sidereal_spec.rb
@@ -91,8 +91,17 @@ RSpec.describe Sidereal::Configuration do
   end
 
   it 'allows setting a custom dispatcher class' do
-    custom_dispatcher = Class.new
+    custom_dispatcher = Class.new do
+      def self.start = new
+    end
+
     config.dispatcher = custom_dispatcher
     expect(config.dispatcher).to eq(custom_dispatcher)
+
+    invalid_dispatcher = Class.new
+
+    expect {
+      config.dispatcher = invalid_dispatcher
+    }.to raise_error(Plumb::ParseError)
   end
 end

--- a/spec/sidereal_spec.rb
+++ b/spec/sidereal_spec.rb
@@ -85,9 +85,19 @@ RSpec.describe Sidereal::Configuration do
   end
 
   it 'allows setting a custom pubsub' do
-    custom_pubsub = Object.new
+    custom_pubsub = Class.new do
+      def self.start = new
+      def self.subscribe(...) = self
+      def self.publish(...) = self
+    end
+
     config.pubsub = custom_pubsub
     expect(config.pubsub).to eq(custom_pubsub)
+
+    invalid_pubsub = Class.new
+    expect {
+      config.pubsub = invalid_pubsub
+    }.to raise_error(Plumb::ParseError)
   end
 
   it 'allows setting a custom dispatcher class' do

--- a/spec/sidereal_spec.rb
+++ b/spec/sidereal_spec.rb
@@ -79,9 +79,17 @@ RSpec.describe Sidereal::Configuration do
   end
 
   it 'allows setting a custom store' do
-    custom_store = Object.new
+    custom_store = Class.new do
+      def self.append(...) = self
+    end
+
     config.store = custom_store
     expect(config.store).to eq(custom_store)
+
+    invalid_store = Class.new
+    expect {
+      config.store = invalid_store
+    }.to raise_error(Plumb::ParseError)
   end
 
   it 'allows setting a custom pubsub' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,14 @@
 
 require 'debug'
 require 'async'
+require 'console'
+require 'logger'
 require "sidereal"
+
+# Silence Console logs during tests — error/warn output from intentional
+# failure-path tests (dispatcher handler errors, publish errors) drowns
+# out the rspec progress otherwise. Set CONSOLE_LEVEL=debug to re-enable.
+Console.logger.level = Logger::FATAL unless ENV['CONSOLE_LEVEL']
 
 module SiderealSpecHelpers
   # Drain `count` messages from a store and return them.


### PR DESCRIPTION
## What

A new pubsub backend, `Sidereal::PubSub::Unix`, that delivers messages across Sidereal processes on the same machine via a Unix domain socket. Drop-in replacement for `PubSub::Memory` — same public contract (`subscribe`/`unsubscribe`/`publish` + `Channel#start`/`#stop`).

```ruby
Sidereal.configure do |c|
  c.pubsub = Sidereal::PubSub::Unix.new(
    socket_path: 'tmp/sidereal-pubsub.sock',
    lock_path:   'tmp/sidereal-pubsub.lock'
  )
end
```

Multiple Sidereal processes pointing at the same paths share pubsub state with no separate broker daemon to deploy.

Also includes:
- `Sidereal::PubSub::Pattern` — NATS-style wildcard validation/compilation extracted from `Memory` so both backends share one implementation.
- `benchmark/unix_pubsub.rb` — throughput + latency benchmark with `--inproc` and `--xproc` modes.
- `examples/chat/falcon.rb` accepts `PORT=` env var for running multiple instances on different ports against the same shared transport.
- Pre-existing latent bug fix in `lib/sidereal/falcon/environment.rb` (Falcon 0.55+ no longer auto-loads `Falcon::Environment::Server`/`Rackup` — added explicit requires; this was breaking *every* example app that booted via `falcon-host`).

## Why

`PubSub::Memory` only delivers within a single Ruby process — fine for development and tests but it falls apart the moment a Sidereal app runs more than one Falcon worker, or splits publishers and subscribers into separate processes. This PR adds a cross-process equivalent for single-host deployments.

`async-bus` does something similar but adds the entire RPC/proxy/transaction layer; this is a focused fan-out broadcast that uses just the low-level patterns (Unix endpoint, framed wire format, reconnect-with-backoff, `task.async(transient: true)` lifecycle) without the heavyweight machinery.

## How

- **Topology — embedded leader, no separate broker process.** The first Sidereal process to acquire `flock(LOCK_EX | LOCK_NB)` on the lock file becomes the broker; it binds the Unix socket and runs an in-process fan-out fiber. Other processes fail the lock and `connect()` as plain clients. `flock` is auto-released by the kernel on process death — no stale-lock cleanup is required.
- **Failure detection is kernel-driven.** When the leader dies, every connected client immediately sees EOF on its read loop, enters reconnect-with-backoff, and re-races for `flock`. Whoever wins becomes the new broker. No heartbeats, no polling, no PID files.
- **Wire format — newline-delimited JSON.** One frame type: `{"channel": "...", "msg": <Message#to_h with iso8601 Times>}\n`. No new gem dependency.
- **Wildcard matching is client-side.** The broker is a dumb fan-out: every published frame goes to every connected peer (excluding the originator), and each client filters incoming frames against its local `Channel` patterns. This keeps the broker stateless, so failover is just "reconnect" — no SUBSCRIBE replay protocol.
- **Lifecycle.** `Dispatcher#spawn_into(task)` calls `@pubsub.start(task)` so the `run_client` fiber is parented by the long-lived dispatcher task, not whatever short-lived fiber happened to publish first. `ensure_started` walks `Async::Task.current` up to the root task as a safety net for non-dispatcher callers.
- **Backpressure.** Per-peer bounded write queue on the broker; if a peer falls more than `write_queue_size` (default 1000) frames behind, the broker drops the connection and logs a warn — the peer's reconnect loop will pick back up. Local in-process fanout uses the unbounded `Async::Queue` from `Memory`.
- **Public interface unchanged.** `Memory` and `Unix` share the same contract; tests written against the contract (`spec/pubsub/memory_spec.rb`) all pass against `Unix` (`spec/pubsub/unix_spec.rb`) with the same matrix.

## Test plan

- [x] `bundle exec rspec` — 238 examples, 0 failures
- [x] `spec/pubsub/pattern_spec.rb` — extracted module unit tests (19 cases)
- [x] `spec/pubsub/unix_spec.rb` — single-process matrix mirroring `memory_spec.rb` (14 cases) + leader election
- [x] `spec/pubsub/unix_failover_spec.rb` — fork-based cross-process tests: fan-out, election across 3 processes, leader-death failover, publish-without-broker (4 cases)
- [x] Manual: two `bundle exec falcon-host` instances of the chat example with `count 3` against the same socket path; messages submitted on either port surface across all browser tabs; killing the leader process triggers election in survivors and message flow resumes after a brief reconnect blip
- [x] Benchmark: `benchmark/unix_pubsub.rb --inproc -n 50 -m 1000` ≈ 50K msg/s; `--xproc -n 10 -m 1000` ≈ 10K msg/s with p50 latency ~155 μs