### PR TITLE
Scheduler + Elector: dynamic and fixed schedules

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,7 @@ PATH
       async
       brotli
       datastar (~> 1.0.4)
+      fugit
       phlex
       plumb (~> 0.0.17)
       rack (~> 3)
@@ -45,10 +46,15 @@ GEM
       reline (>= 0.3.8)
     diff-lcs (1.6.2)
     erb (6.0.2)
+    et-orbi (1.4.0)
+      tzinfo
     fiber-annotation (0.2.0)
     fiber-local (1.1.0)
       fiber-storage
     fiber-storage (1.0.1)
+    fugit (1.12.1)
+      et-orbi (~> 1.4)
+      raabro (~> 1.4)
     io-console (0.8.2)
     io-event (1.14.4)
     irb (1.17.0)
@@ -76,6 +82,7 @@ GEM
     psych (5.3.1)
       date
       stringio
+    raabro (1.4.0)
     rack (3.2.5)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
@@ -109,6 +116,8 @@ GEM
     stringio (3.2.0)
     traces (0.18.2)
     tsort (0.2.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
     zeitwerk (2.7.5)
 
 PLATFORMS
@@ -137,9 +146,11 @@ CHECKSUMS
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
   docco (0.1.0)
   erb (6.0.2) sha256=9fe6264d44f79422c87490a1558479bd0e7dad4dd0e317656e67ea3077b5242b
+  et-orbi (1.4.0) sha256=6c7e3c90779821f9e3b324c5e96fda9767f72995d6ae435b96678a4f3e2de8bc
   fiber-annotation (0.2.0) sha256=7abfadf1d119f508867d4103bf231c0354d019cc39a5738945dec2edadaf6c03
   fiber-local (1.1.0) sha256=c885f94f210fb9b05737de65d511136ea602e00c5105953748aa0f8793489f06
   fiber-storage (1.0.1) sha256=f48e5b6d8b0be96dac486332b55cee82240057065dc761c1ea692b2e719240e1
+  fugit (1.12.1) sha256=5898f478ede9b415f0804e42b8f3fd53f814bd85eebffceebdbc34e1107aaf68
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   io-event (1.14.4) sha256=455a9e4fb4613d12867b90461c297af6993b400a521bf62046f83b27f9c6aa3d
   irb (1.17.0) sha256=168c4ddb93d8a361a045c41d92b2952c7a118fa73f23fe14e55609eb7a863aae
@@ -154,6 +165,7 @@ CHECKSUMS
   prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   psych (5.3.1) sha256=eb7a57cef10c9d70173ff74e739d843ac3b2c019a003de48447b2963d81b1974
+  raabro (1.4.0) sha256=d4fa9ff5172391edb92b242eed8be802d1934b1464061ae5e70d80962c5da882
   rack (3.2.5) sha256=4cbd0974c0b79f7a139b4812004a62e4c60b145cba76422e288ee670601ed6d3
   rack-session (2.1.1) sha256=0b6dc07dea7e4b583f58a48e8b806d4c9f1c6c9214ebc202ec94562cbea2e4e9
   rack-test (2.2.0) sha256=005a36692c306ac0b4a9350355ee080fd09ddef1148a5f8b2ac636c720f5c463
@@ -171,6 +183,7 @@ CHECKSUMS
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
   traces (0.18.2) sha256=80f1649cb4daace1d7174b81f3b3b7427af0b93047759ba349960cb8f315e214
   tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
+  tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
   zeitwerk (2.7.5) sha256=d8da92128c09ea6ec62c949011b00ed4a20242b255293dd66bf41545398f73dd
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -181,31 +181,6 @@ command AddTodo do |cmd|
 end
 ```
 
-### Scheduled commands
-
-Chain `.at(time)` or `.in(seconds)` on a `dispatch` call to defer processing of a command (or event) until a future time:
-
-```ruby
-command PlaceOrder do |cmd|
-  ORDERS[cmd.id] = cmd.payload.to_h
-
-  # Run an hour from now
-  dispatch(SendReminder, order_id: cmd.id).in(3600)
-
-  # Run at a specific time
-  dispatch(ExpireOrder, order_id: cmd.id).at(Time.now + 86400)
-end
-```
-
-The dispatched message lands on the store with its `created_at` set to the scheduled time. Stores that support scheduled delivery hold the message back and only deliver it once that time has passed:
-
-| Store | Scheduled delivery |
-|---|---|
-| `Store::FileSystem` | Honored — future-dated messages are written to a `scheduled/` directory and promoted by a background fiber when due. |
-| `Store::Memory` | Ignored — messages are delivered immediately regardless of `created_at`. Use `FileSystem` when you need scheduling. |
-
-Scheduling does not propagate across correlation: an event dispatched downstream of a scheduled command runs at its own `created_at` (i.e. immediately), not at the source's future time.
-
 ### Broadcast
 
 Use `broadcast` inside a command handler to publish a message immediately to the SSE stream, without waiting for the command to finish processing. Useful for progress indicators.
@@ -570,6 +545,172 @@ end
 ```
 
 A `BasicLayout` with reset CSS and form styling is provided by default if no layout is specified.
+
+## Working with time
+
+### Dynamically scheduled commands
+
+Chain `.at(time)` or `.in(duration)` (aliases) on a `dispatch` call to defer processing of a command (or event) until a future time. Three accepted forms:
+
+| Form                | Example                       | Resolution                                              |
+| ------------------- | ----------------------------- | ------------------------------------------------------- |
+| `Time` / `DateTime` | `.at(Time.now + 86400)`       | Absolute target.                                        |
+| `Integer`           | `.in(3600)`                   | Seconds added to `Time.now`.                            |
+| Duration `String`   | `.at('5m')`, `.in('PT1H30M')` | Parsed via `Fugit.parse_duration`, added to `Time.now`. |
+
+```ruby
+command PlaceOrder do |cmd|
+  ORDERS[cmd.id] = cmd.payload.to_h
+
+  # Run an hour from now — Integer form
+  dispatch(SendReminder, order_id: cmd.id).in(3600)
+
+  # Run 30 minutes from now — Fugit duration String
+  dispatch(NudgeUser, order_id: cmd.id).in('30m')
+
+  # Run at a specific instant — Time form
+  dispatch(ExpireOrder, order_id: cmd.id).at(Time.now + 86400)
+
+  # ISO8601 durations also work
+  dispatch(SendDigest, order_id: cmd.id).in('PT1H')
+end
+```
+
+Resolved targets earlier than the message's `created_at` raise `Sidereal::PastMessageDateError` — including negative integers (`.in(-60)`) and durations that resolve to the past.
+
+The dispatched message is appended to the store with its `created_at` set to the resolved target. Stores that support scheduled delivery hold the message back and only deliver it once that time has passed:
+
+| Store               | Scheduled delivery                                           |
+| ------------------- | ------------------------------------------------------------ |
+| `Store::FileSystem` | Honored — future-dated messages are written to a `scheduled/` directory and promoted by a background fiber when due. |
+| `Store::Memory`     | Ignored — messages are delivered immediately regardless of `created_at`. Use `FileSystem` when you need scheduling. |
+
+Scheduling does not propagate across correlation: an event dispatched downstream of a scheduled command runs at its own `created_at` (i.e. immediately), not at the source's future time.
+
+### Fixed schedules
+
+`App.schedule` registers a sequence of moments in time where commands should fire. The Scheduler is a leader-only fiber that, on each tick, appends commands to the same store the rest of your app uses — so schedule handlers run on the worker pool, in parallel with everything else, with the same retry / dead-letter machinery.
+
+##### The basics — single-step shorthand
+
+```ruby
+class MyApp < Sidereal::App
+  schedule 'Daily cleanup', '5 0 * * *' do |cmd|
+    # Runs every day at 00:05.
+    # `cmd` is the auto-generated command, materialised as
+    # MyApp::Commander::Schedules::SchedDailyCleanup0Step0.
+    dispatch SweepStaleOrders, older_than: '1d'
+  end
+end
+```
+
+The schedule name (`'Daily cleanup'`) is mandatory — it shows up in dead-letter sidecars, dashboards, and `cmd.metadata[:schedule_name]` so handlers and reactions can identify the source.
+
+##### Expressions
+
+A step's expression is anything `Fugit.parse` accepts, plus stdlib `Time` / `DateTime` instances:
+
+| Kind                  | Example                       | Behaviour                                              |
+| --------------------- | ----------------------------- | ------------------------------------------------------ |
+| Specific datetime     | `'2026-12-31T10:00:00'`       | Fires once at that instant.                            |
+| `Time` instance       | `Time.now + 60`               | Fires once at that instant (coerced internally).       |
+| Cron (5- or 6-field)  | `'5 0 * * *'`, `'*/5 * * * *'`| Recurring at every cron match.                         |
+| Natural language      | `'every 3 seconds'`           | Recurring.                                             |
+| Duration              | `'10d'`, `'1h30m'`, `'P12Y12M'`| Fires once at *previous concrete time + duration*.    |
+
+##### Multi-step schedules — sequence of `at` calls
+
+For workflows that don't fit a single step, drop the second positional and use the inner DSL — each `at` call appends a step to the schedule:
+
+```ruby
+schedule 'Flash sale campaign' do
+  at '2026-05-10T10:00:00' do |cmd|
+    # Fires once at this exact moment.
+    dispatch OpenSale, sale_id: 'flash-2026'
+  end
+
+  at 'every day at 9am' do |cmd|
+    # Recurring — fires daily until the next concrete step.
+    dispatch SendDailyReminders
+  end
+
+  at '10d' do |cmd|
+    # Fires once at "previous concrete + 10 days".
+    # This concrete time also closes the recurring step above.
+    dispatch CloseSale, sale_id: 'flash-2026'
+  end
+end
+```
+
+Steps are validated at registration:
+
+- **No time travel.** A specific datetime must be strictly after the previously resolved concrete time.
+- **No back-to-back recurring steps.** A recurring step can't follow another recurring step — the first one would have no end. Insert a specific or duration step between them.
+- **Durations resolve against the last *concrete* step**, not against any intervening recurring step. So in the example above, `'10d'` is "10 days after the `'2026-05-10T10:00:00'` opening step", not "10 days after the recurring started". The resolved time also closes the recurring window.
+- **A trailing recurring step has no upper bound** and runs forever.
+
+##### Bound-only marker steps
+
+Drop the block / class for a specific or duration step to declare a **bound-only marker** — anchors the timeline without dispatching anything. Useful as a starting boundary for a following recurring step, or as a closing boundary for a preceding one:
+
+```ruby
+schedule 'Office hours' do
+  at '2026-05-10T09:00:00'                # marker — opens the window, no command
+  at 'every 5 minutes' do |cmd|
+    dispatch HealthCheck
+  end
+  at '2026-05-10T17:00:00'                # marker — closes the recurring, no command
+end
+```
+
+Block-less markers only work for specific or duration steps. A recurring step without a block would fire nothing on every match — meaningless — so it raises at registration.
+
+##### Explicit command classes (skip auto-generation)
+
+By default, each `at` block generates a per-step command class under `<HostCommander>::Schedules` (e.g. `MyApp::Commander::Schedules::SchedDailyCleanup0Step0` — `Sched<CamelName><ScheduleId>Step<StepIndex>`). For steps that should dispatch a domain command you've already defined elsewhere, pass the class + payload kwargs instead of a block:
+
+```ruby
+# Define explicit commands and handlers
+StartCampaign = Sidereal::Message.define('myapp.start_campaign')
+command StartCampaign do |cmd|
+  # do something here
+end
+
+# Now just define time-based triggers for your own commands
+schedule 'Flash sale campaign' do
+  at '2026-05-10T10:00:00', StartCampaign
+  at 'every day at 9am',    SendEmails, sender: 'acme@company.org'
+  at '10d',                 EndCampaign
+end
+```
+
+In the explicit form the macro generates *no* class and defines *no* handler — it just passes the class and payload through to the Scheduler, which dispatches `SendEmails.parse(payload: { sender: 'acme@company.org' }, metadata: { ... })` on every fire. You're responsible for having a `command SendEmails do |cmd| ... end` registered.
+
+You can mix block and explicit forms freely across steps in the same schedule.
+
+##### Metadata stamped on every fire
+
+The Scheduler stamps these metadata keys on every dispatched command:
+
+```ruby
+{
+  producer:       "Schedule #0 'Flash sale campaign' step #1 (every day at 9am)",
+  schedule_name:  "Flash sale campaign"
+}
+```
+
+The producer label includes the schedule's registration index, name, step index, and the step's own expression — so dead-letter sidecars and dashboards can pinpoint which step fired. Both keys propagate to downstream commands via `Message#correlate`, so anything dispatched from inside a schedule handler carries them automatically.
+
+##### Multi-process: only the leader runs the Scheduler
+
+The Scheduler ticks only on the process that holds `Sidereal.elector`. With the default `Elector::AlwaysLeader` (single-process apps) every process is leader; with `Elector::FileSystem` only one process per host runs the tick fiber. The dispatched commands then flow through the normal store, so any worker fiber on any process can pick them up — schedule handlers are not pinned to the leader.
+
+A few caveats worth knowing:
+
+- **At-most-once per tick.** If a process pauses (GC, debugger) past a cron boundary, only the most recent boundary inside the tick window fires. Matches `crond`'s no-catch-up behaviour.
+- **Boundaries crossed during a leader vacancy are lost.** Step boundaries are point-in-time signals, not state declarations — if no leader is running at the boundary, no command is dispatched.
+- **Within a single leader's lifetime, every step fires exactly once at its instant** (or every cron match, for recurring steps). Steps use the half-open tick window `(@last_tick_at, now]` — once the boundary moves into the past it can't be in any future window.
+- **Implicit baseline = scheduler-construction time.** If your first step is a duration (`at '5m', X`), it resolves to `boot + 5m`. Across a leader handoff each leader has its own boot time, so duration-anchored first steps drift; anchor with a specific datetime if stability matters.
 
 ## Router
 

--- a/benchmark/unix_pubsub.rb
+++ b/benchmark/unix_pubsub.rb
@@ -48,6 +48,7 @@ require 'tmpdir'
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'sidereal'
 require 'sidereal/pubsub/unix'
+require 'sidereal/elector/file_system'
 
 opts = {
   subscribers: 10,
@@ -105,8 +106,8 @@ end
 def build(root)
   Sidereal::PubSub::Unix.new(
     socket_path:      File.join(root, 'p.sock'),
-    lock_path:        File.join(root, 'p.lock'),
-    write_queue_size: 1_000_000
+    write_queue_size: 1_000_000,
+    elector: Sidereal::Elector::FileSystem.new(lock_path: File.join(root, 'p.lock'))
   )
 end
 

--- a/examples/chat/Gemfile.lock
+++ b/examples/chat/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
       async
       brotli
       datastar (~> 1.0.4)
+      fugit
       phlex
       plumb (~> 0.0.17)
       rack (~> 3)
@@ -57,6 +58,8 @@ GEM
     date (3.5.1)
     dotenv (3.2.0)
     erb (6.0.2)
+    et-orbi (1.4.0)
+      tzinfo
     event_stream_parser (1.0.0)
     falcon (0.55.2)
       async
@@ -85,6 +88,9 @@ GEM
     fiber-local (1.1.0)
       fiber-storage
     fiber-storage (1.0.1)
+    fugit (1.12.1)
+      et-orbi (~> 1.4)
+      raabro (~> 1.4)
     io-console (0.8.2)
     io-endpoint (0.17.2)
     io-event (1.14.5)
@@ -131,6 +137,7 @@ GEM
     psych (5.3.1)
       date
       stringio
+    raabro (1.4.0)
     rack (3.2.5)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
@@ -163,6 +170,8 @@ GEM
     stringio (3.2.0)
     traces (0.18.2)
     tsort (0.2.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
     uri (1.1.1)
     zeitwerk (2.7.5)
 
@@ -195,6 +204,7 @@ CHECKSUMS
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   dotenv (3.2.0) sha256=e375b83121ea7ca4ce20f214740076129ab8514cd81378161f11c03853fe619d
   erb (6.0.2) sha256=9fe6264d44f79422c87490a1558479bd0e7dad4dd0e317656e67ea3077b5242b
+  et-orbi (1.4.0)
   event_stream_parser (1.0.0) sha256=a2683bab70126286f8184dc88f7968ffc4028f813161fb073ec90d171f7de3c8
   falcon (0.55.2) sha256=dfcdd8e4c3a18827a5ca7e346df67ebdaf873ac61a5f7d20ad4923c4d6b180cb
   faraday (2.14.1) sha256=a43cceedc1e39d188f4d2cdd360a8aaa6a11da0c407052e426ba8d3fb42ef61c
@@ -204,6 +214,7 @@ CHECKSUMS
   fiber-annotation (0.2.0) sha256=7abfadf1d119f508867d4103bf231c0354d019cc39a5738945dec2edadaf6c03
   fiber-local (1.1.0) sha256=c885f94f210fb9b05737de65d511136ea602e00c5105953748aa0f8793489f06
   fiber-storage (1.0.1) sha256=f48e5b6d8b0be96dac486332b55cee82240057065dc761c1ea692b2e719240e1
+  fugit (1.12.1)
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   io-endpoint (0.17.2) sha256=3feaf766c116b35839c11fac68b6aaadc47887bb488902a57bf8e1d288fb3338
   io-event (1.14.5) sha256=68ac367032a3873416dc2e0b67332dfaf2e23b65b58e6465d301c7e5cd9163b1
@@ -231,6 +242,7 @@ CHECKSUMS
   protocol-rack (0.22.0) sha256=b7c49c0b597ca2c6d20f8bcd746c4415a1b750eacfbe64f828e780c978a4293d
   protocol-url (0.4.0) sha256=64d4c03b6b51ad815ac6fdaf77a1d91e5baf9220d26becb846c5459dacdea9e1
   psych (5.3.1) sha256=eb7a57cef10c9d70173ff74e739d843ac3b2c019a003de48447b2963d81b1974
+  raabro (1.4.0)
   rack (3.2.5) sha256=4cbd0974c0b79f7a139b4812004a62e4c60b145cba76422e288ee670601ed6d3
   rack-session (2.1.1) sha256=0b6dc07dea7e4b583f58a48e8b806d4c9f1c6c9214ebc202ec94562cbea2e4e9
   rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
@@ -245,6 +257,7 @@ CHECKSUMS
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
   traces (0.18.2) sha256=80f1649cb4daace1d7174b81f3b3b7427af0b93047759ba349960cb8f315e214
   tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
+  tzinfo (2.0.6)
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
   zeitwerk (2.7.5) sha256=d8da92128c09ea6ec62c949011b00ed4a20242b255293dd66bf41545398f73dd
 

--- a/examples/chat/app.rb
+++ b/examples/chat/app.rb
@@ -6,12 +6,16 @@ Dotenv.load '.env'
 require 'sidereal'
 require 'sidereal/pubsub/unix'
 require 'sidereal/store/file_system'
+require 'sidereal/elector/file_system'
 require 'ruby_llm'
 
 Sidereal.configure do |c|
   c.workers = 3
   c.store = Sidereal::Store::FileSystem.new(root: 'tmp/sidereal-store')
   c.pubsub = Sidereal::PubSub::Unix.new
+  # Only one process per host runs scheduled blocks. Drop this line and
+  # the default AlwaysLeader elector fires schedules in every process.
+  c.elector = Sidereal::Elector::FileSystem.new(lock_path: 'tmp/sidereal-leader.lock')
 end
 
 RubyLLM.configure do |config|
@@ -43,6 +47,13 @@ ChatNotify = Sidereal::Message.define('chat.notify') do
 end
 
 Working = Sidereal::Message.define('chat.working')
+
+SendEmails = Sidereal::Message.define('chat.send_emails') do
+  attribute? :kickoff, Sidereal::Types::Boolean
+  attribute? :sender,  Sidereal::Types::String
+end
+
+EndCampaign = Sidereal::Message.define('chat.end_campaign')
 
 require_relative 'ui/layout'
 require_relative 'ui/chat_page'
@@ -113,6 +124,65 @@ class ChatApp < Sidereal::App
           chat.add_message role: m.payload.role, content: %(#{m.payload.author} said on #{m.created_at}: #{m.payload.content})
         end
         chat
+      )
+    end
+  end
+
+  # User-defined command handlers for an explicit-class schedule.
+  command SendEmails do |cmd|
+    # etc
+  end
+
+  command EndCampaign do |cmd|
+    # etc
+  end
+
+  # Explicit-class form: each `at` step references a class the user
+  # already wired up via `command`. The macro generates no class and
+  # defines no handler.
+  # schedule 'Flash sale campaign' do
+  #   at '2026-05-10T10:00:00', SendEmails, kickoff: true
+  #   at 'every day at 9am',    SendEmails, sender: 'acme@company.org'
+  #   at '10d',                 EndCampaign
+  # end
+
+  # Block form: each `at` step gets an auto-generated class under
+  # ChatApp::Commander::Schedules::SchedTickCampaign0Step{0,1,2}, with
+  # the block as that class's handler.
+  schedule 'Tick campaign' do
+    at Time.now + 10 do |cmd|
+      dispatch(
+        SendMessage,
+        author: 'System',
+        role: 'system',
+        content: "▶ Entered #{cmd.metadata[:schedule_name]} (pid #{Process.pid})"
+      )
+    end
+
+    at 'every 3 seconds' do |cmd|
+      dispatch(
+        SendMessage,
+        author: 'Clock',
+        role: 'system',
+        content: "#{cmd.metadata[:producer]}: The time is #{Time.now.strftime('%H:%M:%S')} (pid #{Process.pid})"
+      )
+    end
+
+    at '10s' do |cmd|
+      dispatch(
+        SendMessage,
+        author: 'Clock',
+        role: 'system',
+        content: 'Last before exit'
+      )
+    end
+
+    at '4s' do |cmd|
+      dispatch(
+        SendMessage,
+        author: 'System',
+        role: 'system',
+        content: "■ Exited #{cmd.metadata[:schedule_name]} (pid #{Process.pid})"
       )
     end
   end

--- a/lib/sidereal.rb
+++ b/lib/sidereal.rb
@@ -10,6 +10,7 @@ module Sidereal
 
   DispatcherInterface = Types::Interface[:start]
   PubsubInterface = Types::Interface[:start, :subscribe, :publish]
+  ElectorInterface = Types::Interface[:start, :on_promote, :on_demote, :leader?]
   # Sidereal apps only append to stores
   # It's up to dispatcher implementations how to use the store to claim commands
   # Ex. Sourced's store has a more sophisticated claim mechanism than Sidereal::Store
@@ -24,13 +25,14 @@ module Sidereal
 
   class Configuration
     attr_accessor :workers
-    attr_reader :store, :pubsub, :dispatcher
+    attr_reader :store, :pubsub, :dispatcher, :elector
 
     def initialize(workers: 25)
       @workers = workers
       @pubsub = PubSub::Memory.instance
       @store = Store::Memory.instance
       @dispatcher = Sidereal::Dispatcher
+      @elector = Elector::AlwaysLeader.new
     end
 
     def store=(s)
@@ -43,6 +45,10 @@ module Sidereal
 
     def dispatcher=(d)
       @dispatcher = DispatcherInterface.parse(d)
+    end
+
+    def elector=(e)
+      @elector = ElectorInterface.parse(e)
     end
   end
 
@@ -79,6 +85,7 @@ module Sidereal
   def self.pubsub = config.pubsub
   def self.store = config.store
   def self.dispatcher = config.dispatcher
+  def self.elector = config.elector
 
   # Build (if needed) and append a command to the configured {.store} from
   # outside the request/handler lifecycle. Use this from CLIs, consoles,
@@ -136,6 +143,7 @@ require_relative 'sidereal/store'
 require_relative 'sidereal/store/memory'
 require_relative 'sidereal/registry'
 require_relative 'sidereal/dispatcher'
+require_relative 'sidereal/elector'
 require_relative 'sidereal/scheduler'
 require_relative 'sidereal/app'
 require_relative 'sidereal/components/command'

--- a/lib/sidereal.rb
+++ b/lib/sidereal.rb
@@ -62,6 +62,14 @@ module Sidereal
     @registry = nil
   end
 
+  def self.scheduler
+    @scheduler ||= Scheduler.new
+  end
+
+  def self.reset_scheduler!
+    @scheduler = nil
+  end
+
   def self.register(commander)
     commander.handled_commands.each do |cmd_class|
       registry[cmd_class] = commander
@@ -128,5 +136,6 @@ require_relative 'sidereal/store'
 require_relative 'sidereal/store/memory'
 require_relative 'sidereal/registry'
 require_relative 'sidereal/dispatcher'
+require_relative 'sidereal/scheduler'
 require_relative 'sidereal/app'
 require_relative 'sidereal/components/command'

--- a/lib/sidereal.rb
+++ b/lib/sidereal.rb
@@ -3,6 +3,7 @@
 require 'async'
 require_relative 'sidereal/version'
 require_relative 'sidereal/types'
+require_relative 'sidereal/utils'
 
 module Sidereal
   class Error < StandardError; end

--- a/lib/sidereal/app.rb
+++ b/lib/sidereal/app.rb
@@ -157,7 +157,7 @@ module Sidereal
           schedule = Sidereal.scheduler.find(cmd.payload.schedule_id)
           return unless schedule
 
-          schedule.run_in(self)
+          schedule.run_in(self, cmd)
         end
         self
       end

--- a/lib/sidereal/app.rb
+++ b/lib/sidereal/app.rb
@@ -137,6 +137,24 @@ module Sidereal
         self
       end
 
+      # Register a cron-scheduled block. The block runs on every tick of
+      # the cron expression, on a fiber spawned by {Sidereal.scheduler}.
+      # Inside the block, +dispatch(MessageClass, payload)+ enqueues a
+      # command onto {Sidereal.store} stamped with
+      # +metadata: { producer: '<cron expr>' }+.
+      #
+      # @example
+      #   schedule '5 0 * * *' do
+      #     dispatch Cleanup, foo: 'bar'
+      #   end
+      #
+      # @param cron_expr [String] cron expression (5 or 6 fields)
+      # @return [self]
+      def schedule(cron_expr, &block)
+        Sidereal.scheduler.schedule(cron_expr, &block)
+        self
+      end
+
       # Expose a command to the web (+POST /commands+) and register a
       # handler that runs synchronously during the HTTP request.
       #

--- a/lib/sidereal/app.rb
+++ b/lib/sidereal/app.rb
@@ -137,28 +137,9 @@ module Sidereal
         self
       end
 
-      # Register a cron-scheduled block. The block runs on every tick of
-      # the cron expression, on a fiber spawned by {Sidereal.scheduler}.
-      # Inside the block, +dispatch(MessageClass, payload)+ enqueues a
-      # command onto {Sidereal.store} stamped with
-      # +metadata: { producer: '<cron expr>' }+.
-      #
-      # @example
-      #   schedule '5 0 * * *' do
-      #     dispatch Cleanup, foo: 'bar'
-      #   end
-      #
-      # @param cron_expr [String] cron expression (5 or 6 fields)
-      # @return [self]
-      def schedule(cron_expr, &block)
-        Sidereal.scheduler.schedule(cron_expr, &block)
-
-        command Sidereal::System::TriggerSchedule do |cmd|
-          schedule = Sidereal.scheduler.find(cmd.payload.schedule_id)
-          return unless schedule
-
-          schedule.run_in(self, cmd)
-        end
+      def schedule(...)
+        commander.schedule(...)
+        Sidereal.register(commander)
         self
       end
 

--- a/lib/sidereal/app.rb
+++ b/lib/sidereal/app.rb
@@ -152,6 +152,13 @@ module Sidereal
       # @return [self]
       def schedule(cron_expr, &block)
         Sidereal.scheduler.schedule(cron_expr, &block)
+
+        command Sidereal::System::TriggerSchedule do |cmd|
+          schedule = Sidereal.scheduler.find(cmd.payload.schedule_id)
+          return unless schedule
+
+          schedule.run_in(self)
+        end
         self
       end
 

--- a/lib/sidereal/commander.rb
+++ b/lib/sidereal/commander.rb
@@ -4,7 +4,7 @@ require_relative 'scheduling'
 
 module Sidereal
   class Commander
-    extend Scheduling
+    include Scheduling
 
     CMD_METHOD_PREFIX = '__cmd_'
     CMD_HASH = Types::Hash[type: String, payload?: Hash]

--- a/lib/sidereal/commander.rb
+++ b/lib/sidereal/commander.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
+require_relative 'scheduling'
+
 module Sidereal
   class Commander
+    extend Scheduling
+
     CMD_METHOD_PREFIX = '__cmd_'
     CMD_HASH = Types::Hash[type: String, payload?: Hash]
     DEFAULT_CMD_HANDLER = ->(*_) {}

--- a/lib/sidereal/elector.rb
+++ b/lib/sidereal/elector.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module Sidereal
+  # Leader election. Modules that should run only on a single elected
+  # process per host (or cluster, eventually) inject an Elector and react
+  # to +on_promote+ / +on_demote+ transitions.
+  #
+  # @example
+  #   elector.on_promote do
+  #     # this process is now leader
+  #   end.on_demote do
+  #     # this process is no longer leader (or never was)
+  #   end
+  #   elector.start(task)
+  #
+  # Callback semantics:
+  # * +on_promote(&block)+ — registers the block, then calls it
+  #   immediately if currently leader. Fires on every future
+  #   follower→leader transition.
+  # * +on_demote(&block)+ — registers the block, then calls it
+  #   immediately if currently follower (the initial state of a fresh
+  #   elector). Fires on every future leader→follower transition.
+  #
+  # Implementations must call +promote!+ / +demote!+ from {#start}'s
+  # election loop. Both are idempotent — repeated calls in the same
+  # state are no-ops, so callbacks fire exactly once per transition.
+  module Elector
+    # Mixin: callback registry + transition gating. Including class
+    # owns the +@leader+ ivar and calls +promote!+ / +demote!+ from
+    # its election strategy.
+    module Callbacks
+      def on_promote(&block)
+        (@on_promote ||= []) << block
+        block.call if leader?
+        self
+      end
+
+      def on_demote(&block)
+        (@on_demote ||= []) << block
+        block.call unless leader?
+        self
+      end
+
+      private
+
+      def promote!
+        return if @leader
+        @leader = true
+        invoke_callbacks(@on_promote, :on_promote)
+      end
+
+      def demote!
+        return unless @leader
+        @leader = false
+        invoke_callbacks(@on_demote, :on_demote)
+      end
+
+      # A raising callback must not kill the election fiber or prevent
+      # sibling callbacks from running — log it and move on. Pubsub's
+      # broker setup, for example, can raise EADDRINUSE on a stale
+      # socket; that's the caller's problem to surface, not the
+      # elector's to crash on.
+      def invoke_callbacks(callbacks, kind)
+        (callbacks || []).each do |cb|
+          cb.call
+        rescue StandardError => ex
+          Console.error(self, 'elector callback raised', kind: kind, exception: ex)
+        end
+      end
+    end
+
+    # Default elector. Always leader, never demotes. Used by single-
+    # process apps where no election is needed (e.g. the Memory store +
+    # Memory pubsub default).
+    class AlwaysLeader
+      include Callbacks
+
+      def initialize
+        @leader = true
+      end
+
+      def leader? = @leader
+
+      def start(_task)
+        self
+      end
+    end
+  end
+end

--- a/lib/sidereal/elector/file_system.rb
+++ b/lib/sidereal/elector/file_system.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'console'
+
+module Sidereal
+  module Elector
+    # Filesystem-backed leader election via +flock+ on a shared lock
+    # file. Single-host only — flock is unreliable across NFS.
+    #
+    # The first process to acquire +LOCK_EX | LOCK_NB+ on +lock_path+
+    # becomes leader and holds the lock until the process exits or the
+    # election fiber is cancelled (whichever comes first). Followers
+    # poll +retry_interval+ seconds to detect a vacancy. flock is
+    # auto-released by the kernel on process death — no stale-lock
+    # cleanup required.
+    #
+    # Topologically equivalent to the embedded election used by
+    # {Sidereal::PubSub::Unix}, but standalone and reusable.
+    class FileSystem
+      include Callbacks
+
+      DEFAULT_RETRY_INTERVAL = 1.0
+
+      attr_reader :lock_path
+
+      def initialize(lock_path:, retry_interval: DEFAULT_RETRY_INTERVAL)
+        @lock_path = File.expand_path(lock_path)
+        @retry_interval = retry_interval
+        @leader = false
+        @lock_io = nil
+        FileUtils.mkdir_p(File.dirname(@lock_path))
+      end
+
+      def leader? = @leader
+
+      # Spawn the election fiber as a transient child of +task+. The
+      # fiber polls for the lock until acquired, then sleeps holding
+      # it. Cancellation (parent task ending or {#stop}) releases the
+      # lock and fires +on_demote+ callbacks via the +ensure+ block.
+      # Idempotent — safe to call multiple times (e.g. once from
+      # {Falcon::Environment::Service} and once from
+      # {PubSub::Unix#start}).
+      def start(task)
+        return self if @election_task
+
+        @election_task = task.async(transient: true) do
+          run_election
+        ensure
+          release_lock
+          demote!
+        end
+        self
+      end
+
+      # Voluntarily step down: cancel the election fiber, which
+      # releases the flock and fires +on_demote+ via the +ensure+
+      # block in {#start}. Idempotent.
+      def stop
+        t = @election_task
+        @election_task = nil
+        t&.stop
+        self
+      end
+
+      private
+
+      def run_election
+        loop do
+          if try_acquire_lock
+            promote!
+            # Hold the lock indefinitely. flock survives until the file
+            # is closed (cancellation path) or the process dies. A long
+            # sleep keeps the fiber alive without busy-waiting; the
+            # transient cancellation interrupts it cleanly.
+            loop { sleep 3600 }
+          else
+            sleep @retry_interval
+          end
+        end
+      end
+
+      def try_acquire_lock
+        io = File.open(@lock_path, File::RDWR | File::CREAT, 0o644)
+        if io.flock(File::LOCK_EX | File::LOCK_NB)
+          @lock_io = io
+          Console.info(self, 'elected as leader', pid: Process.pid, lock: @lock_path)
+          true
+        else
+          io.close
+          false
+        end
+      end
+
+      def release_lock
+        return unless @lock_io
+
+        io = @lock_io
+        @lock_io = nil
+        io.close rescue nil
+        Console.info(self, 'stepped down', pid: Process.pid, lock: @lock_path)
+      end
+    end
+  end
+end

--- a/lib/sidereal/elector/file_system.rb
+++ b/lib/sidereal/elector/file_system.rb
@@ -14,9 +14,6 @@ module Sidereal
     # poll +retry_interval+ seconds to detect a vacancy. flock is
     # auto-released by the kernel on process death — no stale-lock
     # cleanup required.
-    #
-    # Topologically equivalent to the embedded election used by
-    # {Sidereal::PubSub::Unix}, but standalone and reusable.
     class FileSystem
       include Callbacks
 

--- a/lib/sidereal/elector/file_system.rb
+++ b/lib/sidereal/elector/file_system.rb
@@ -35,9 +35,7 @@ module Sidereal
       # fiber polls for the lock until acquired, then sleeps holding
       # it. Cancellation (parent task ending or {#stop}) releases the
       # lock and fires +on_demote+ callbacks via the +ensure+ block.
-      # Idempotent — safe to call multiple times (e.g. once from
-      # {Falcon::Environment::Service} and once from
-      # {PubSub::Unix#start}).
+      # Idempotent.
       def start(task)
         return self if @election_task
 

--- a/lib/sidereal/falcon/environment.rb
+++ b/lib/sidereal/falcon/environment.rb
@@ -47,6 +47,7 @@ module Sidereal
             # plugged in — e.g. Sourced's Dispatcher in examples/sourced_donations
             # also benefits from the long-lived Falcon task as the parent for
             # pubsub's background fibers.
+            Sidereal.elector.start(task)
             Sidereal.pubsub.start(task)
             @dispatcher = Sidereal.dispatcher.start(task)
             Sidereal.scheduler.start(task)

--- a/lib/sidereal/falcon/environment.rb
+++ b/lib/sidereal/falcon/environment.rb
@@ -49,6 +49,7 @@ module Sidereal
             # pubsub's background fibers.
             Sidereal.pubsub.start(task)
             @dispatcher = Sidereal.dispatcher.start(task)
+            Sidereal.scheduler.start(task)
 
             task.children.each(&:wait)
           end

--- a/lib/sidereal/message.rb
+++ b/lib/sidereal/message.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'fugit'
+
 module Sidereal
   UnknownMessageError = Class.new(ArgumentError)
   PastMessageDateError = Class.new(ArgumentError)
@@ -152,13 +154,39 @@ module Sidereal
       self.class.new(hash)
     end
 
-    def at(datetime)
-      if datetime < created_at
+    # Return a copy with +created_at+ set to a future instant. Three
+    # accepted forms:
+    #
+    # - +Time+ / +DateTime+ / anything with +<+ — used as the absolute
+    #   target.
+    # - +Integer+ — interpreted as seconds; added to +Time.now+.
+    # - +String+ — parsed via +Fugit.parse+ as a duration (e.g.
+    #   +'5m'+, +'1h30m'+, +'PT5M'+) and added to +Time.now+.
+    #
+    # Raises +PastMessageDateError+ when the resolved target is
+    # before +created_at+.
+    def at(value)
+      target = case value
+               when Integer
+                 Time.now + value
+               when String
+                 parsed = Fugit.parse_duration(value) or
+                   raise ArgumentError,
+                         "Message#at: String argument must be an ISO8601 / Fugit duration " \
+                         "(e.g. '5m', 'PT1H30M'); got #{value.inspect}"
+                 parsed.add_to_time(Time.now).to_local_time
+               else
+                 value
+               end
+
+      if target < created_at
         raise PastMessageDateError, "Message #{type} can't be delayed to a date in the past"
       end
 
-      with(created_at: datetime)
+      with(created_at: target)
     end
+
+    alias in at
 
     # Set causation and correlation IDs on another message, establishing
     # a causal link from this message to +message+. Merges metadata.

--- a/lib/sidereal/pubsub/unix.rb
+++ b/lib/sidereal/pubsub/unix.rb
@@ -10,13 +10,14 @@ module Sidereal
   module PubSub
     # Unix-domain-socket pubsub for cross-process delivery on a single host.
     #
-    # Topology: embedded leader. The first process to acquire a +flock+ on
-    # +lock_path+ binds +socket_path+ and runs an in-process broker fiber
+    # Topology: embedded leader, election delegated to an injected
+    # {Sidereal::Elector}. When the elector promotes this process,
+    # Pubsub binds +socket_path+ and runs an in-process broker fiber
     # that fans out frames to every connected peer. Other processes
-    # +connect+ as plain clients. When the leader dies, the kernel closes
-    # its listening socket; clients see EOF and re-run election +
-    # connection inside their reconnect-with-backoff loop. +flock+ is
-    # auto-released on process death — no stale-lock cleanup required.
+    # +connect+ as plain clients. When the leader dies, the elector
+    # detects the vacancy and a successor is promoted; meanwhile,
+    # clients see EOF and reconnect via the broker socket once the
+    # new broker has bound it.
     #
     # Wire format: newline-delimited JSON, one frame type:
     #
@@ -29,7 +30,6 @@ module Sidereal
     # Public contract is identical to {PubSub::Memory}.
     class Unix
       DEFAULT_SOCKET = 'tmp/sidereal-pubsub.sock'
-      DEFAULT_LOCK   = 'tmp/sidereal-pubsub.lock'
       DEFAULT_WRITE_QUEUE = 1_000
 
       # macOS sockaddr_un.sun_path is 104 bytes; Linux is 108. Use the smaller.
@@ -37,21 +37,20 @@ module Sidereal
 
       def initialize(
         socket_path: DEFAULT_SOCKET,
-        lock_path: DEFAULT_LOCK,
         reconnect_min: 0.05,
         reconnect_max: 0.5,
-        write_queue_size: DEFAULT_WRITE_QUEUE
+        write_queue_size: DEFAULT_WRITE_QUEUE,
+        elector: nil
       )
         @socket_path = File.expand_path(socket_path)
-        @lock_path = File.expand_path(lock_path)
         validate_socket_path!(@socket_path)
 
         @reconnect_min = reconnect_min
         @reconnect_max = reconnect_max
         @write_queue_size = write_queue_size
+        @elector = elector            # nil = resolve from Sidereal.elector at start time
 
         FileUtils.mkdir_p(File.dirname(@socket_path))
-        FileUtils.mkdir_p(File.dirname(@lock_path))
 
         @mutex = Mutex.new
         @subscribers = {}
@@ -62,27 +61,39 @@ module Sidereal
 
         @send_mutex = Mutex.new
         @client_socket = nil
-        @leader_lock_io = nil
         @server = nil
         @broker_task = nil
 
         @started = false
       end
 
-      # Whether this process currently holds the broker role.
+      # Whether this process currently holds the broker role. Tracks
+      # the elector's view, not the socket state — the broker fiber
+      # itself comes up asynchronously inside +on_promote+.
       # @return [Boolean]
       def leader?
-        !@server.nil?
+        elector = @elector || Sidereal.elector
+        elector.leader?
       end
 
-      # Idempotent. Spawns the election + read loop as a transient child of
-      # +task+; that fiber handles flock election, broker setup when
-      # elected, and reconnect-with-backoff on EOF or error.
+      # Idempotent. Wires broker lifecycle to the elector and spawns a
+      # client-reconnect fiber as a transient child of +task+. The
+      # client fiber polls until the broker socket exists (created by
+      # whichever process the elector promoted) and reads frames.
       def start(task)
         @mutex.synchronize do
           return self if @started
           @started = true
         end
+
+        elector = @elector || Sidereal.elector
+        elector.on_promote { setup_broker(task) }
+        elector.on_demote { teardown_broker }
+        # Idempotent — when wired through Falcon::Service the elector
+        # is already started before pubsub.start runs; this call is a
+        # no-op in that path. For tests / standalone use, this is
+        # what kicks the election off.
+        elector.start(task)
 
         task.async(transient: true) { run_client(task) }
         self
@@ -235,50 +246,63 @@ module Sidereal
         end
       end
 
-      # Try to acquire the leader flock. On success, store the open file
-      # in @leader_lock_io (closing it releases the lock).
-      # @return [Boolean]
-      def try_become_leader
-        io = File.open(@lock_path, File::RDWR | File::CREAT, 0o644)
-        if io.flock(File::LOCK_EX | File::LOCK_NB)
-          @leader_lock_io = io
-          true
-        else
-          io.close
-          false
-        end
+      # Bring up the broker on this process. Called from the elector's
+      # +on_promote+ callback. Replaces any stale socket left by a
+      # dead prior leader. Spawns the broker accept loop as a
+      # transient child of +task+ so it dies cleanly with the service.
+      def setup_broker(task)
+        File.unlink(@socket_path) rescue Errno::ENOENT
+        @server = UNIXServer.new(@socket_path)
+        @broker_task = task.async(transient: true) { run_broker(task) }
+        Console.info(self, 'pubsub: elected as broker', pid: Process.pid, socket: @socket_path)
+      rescue StandardError => ex
+        Console.error(self, 'pubsub broker setup failed', exception: ex)
+        teardown_broker
       end
 
-      # Combined election + connection + read loop with reconnect-with-
-      # backoff. Every iteration re-runs election: when the prior leader
-      # dies, every connected client lands here and races for flock.
-      def run_client(task)
+      # Tear down the broker on this process. Called from the
+      # elector's +on_demote+ callback. Followers (never-promoted
+      # processes) hit this once at startup with no broker to tear
+      # down — all branches are nil-safe.
+      def teardown_broker
+        if (broker = @broker_task)
+          @broker_task = nil
+          broker.stop
+        end
+
+        if (srv = @server)
+          @server = nil
+          srv.close rescue nil
+          Console.info(self, 'pubsub: stepped down as broker', pid: Process.pid)
+        end
+
+        # Drain peers via drop_peer so writer fibers blocked on their
+        # write_queue.pop see the nil sentinel and exit cleanly. A bare
+        # @peers.clear would leak those fibers until parent teardown.
+        @peers.keys.each { |peer| drop_peer(peer) }
+      end
+
+      # Independent reconnect-with-backoff loop. Runs in every process
+      # regardless of election state: the leader connects to its own
+      # broker, followers connect to whoever the elector promoted.
+      # +Errno::ENOENT+ / +ECONNREFUSED+ during startup or failover
+      # are normal — keep retrying.
+      def run_client(_task)
         loop do
-          run_one_connection(task)
+          run_one_connection
+        rescue Errno::ENOENT, Errno::ECONNREFUSED
+          # broker not up yet (startup) or just stepped down (failover) — retry
         rescue StandardError => ex
           Console.warn(self, 'pubsub client iteration error', exception: ex)
         ensure
-          tear_down_connection
+          tear_down_client
           sleep(rand_backoff)
         end
       end
 
-      def run_one_connection(task)
-        if try_become_leader
-          # Replace any stale socket from a dead prior leader.
-          begin
-            File.unlink(@socket_path)
-          rescue Errno::ENOENT
-            # nothing to clean up
-          end
-          @server = UNIXServer.new(@socket_path)
-          @broker_task = task.async(transient: true) { run_broker(task) }
-          Console.info(self, "pubsub: elected as broker", pid: Process.pid, socket: @socket_path)
-        else
-          Console.info(self, "pubsub: connecting as client", pid: Process.pid, socket: @socket_path)
-        end
-
+      def run_one_connection
         @client_socket = UNIXSocket.new(@socket_path)
+        Console.info(self, 'pubsub: connecting as client', pid: Process.pid, socket: @socket_path)
 
         @client_socket.each_line do |line|
           begin
@@ -289,32 +313,10 @@ module Sidereal
         end
       end
 
-      def tear_down_connection
-        if (sock = @client_socket)
-          @client_socket = nil
-          sock.close rescue nil
-        end
-
-        if (broker = @broker_task)
-          @broker_task = nil
-          broker.stop
-        end
-
-        if (srv = @server)
-          @server = nil
-          srv.close rescue nil
-        end
-
-        if (lock = @leader_lock_io)
-          @leader_lock_io = nil
-          lock.close rescue nil
-          Console.info(self, "pubsub: stepped down as broker", pid: Process.pid)
-        end
-
-        # Drain peers via drop_peer so writer fibers blocked on their
-        # write_queue.pop see the nil sentinel and exit cleanly. A bare
-        # @peers.clear would leak those fibers until parent teardown.
-        @peers.keys.each { |peer| drop_peer(peer) }
+      def tear_down_client
+        sock = @client_socket
+        @client_socket = nil
+        sock&.close rescue nil
       end
 
       def rand_backoff

--- a/lib/sidereal/pubsub/unix.rb
+++ b/lib/sidereal/pubsub/unix.rb
@@ -89,10 +89,7 @@ module Sidereal
         elector = @elector || Sidereal.elector
         elector.on_promote { setup_broker(task) }
         elector.on_demote { teardown_broker }
-        # Idempotent — when wired through Falcon::Service the elector
-        # is already started before pubsub.start runs; this call is a
-        # no-op in that path. For tests / standalone use, this is
-        # what kicks the election off.
+        # Idempotent.
         elector.start(task)
 
         task.async(transient: true) { run_client(task) }

--- a/lib/sidereal/scheduler.rb
+++ b/lib/sidereal/scheduler.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'time'   # Time.iso8601
 require 'fugit'
 require 'async'
 
@@ -39,13 +40,22 @@ module Sidereal
     # surfaced on +TriggerSchedule.payload.schedule_name+ and inside
     # the +producer+ metadata hash so dispatched commands carry a
     # readable trail back to the originating schedule.
-    Schedule = Data.define(:id, :name, :cron_expr, :cron, :block) do
+    Schedule = Data.define(:id, :name, :cron_expr, :cron, :from, :to, :block) do
       # Human-readable identifier stamped on +TriggerSchedule.metadata[:producer]+
       # and inherited by every command dispatched from the schedule
       # block via +Message#correlate+. Single-line string so it can sit
       # comfortably in logs, dead-letter sidecars, and chat messages.
       def producer_label
         "Schedule ##{id} '#{name}' (#{cron_expr})"
+      end
+
+      # Whether this schedule should be considered for firing at +time+.
+      # Bounds are inclusive on both ends. Returns +true+ when no
+      # bounds are set (the common case).
+      def active_at?(time)
+        return false if from && time < from
+        return false if to   && time > to
+        true
       end
 
       # Execute the schedule's block on +context+ via instance_exec, so
@@ -80,8 +90,15 @@ module Sidereal
     # - +schedule(cron_expr) { ... }+ — auto-named as +"<id> (<cron_expr>)"+
     # - +schedule(name, cron_expr) { ... }+ — user-supplied name
     #
+    # Optional +from:+ / +to:+ keyword arguments bound the schedule to
+    # a wall-clock window. Each accepts +nil+, a +Time+, a +DateTime+,
+    # or an ISO8601 +String+ (parsed once at registration). When both
+    # are given, the cron expression is validated to fire at least
+    # once inside the window — guarding against e.g. a daily cron
+    # paired with a sub-day window.
+    #
     # @return [self]
-    def schedule(*args, &block)
+    def schedule(*args, from: nil, to: nil, &block)
       name, cron_expr = case args
       in [String => cron_expr]
         [nil, cron_expr]
@@ -91,10 +108,15 @@ module Sidereal
         raise ArgumentError, "schedule takes (cron_expr) or (name, cron_expr); got #{args.inspect}"
       end
 
+      from = coerce_time(from)
+      to   = coerce_time(to)
+
       cron = Fugit.parse_cron(cron_expr) or raise ArgumentError, "invalid cron: #{cron_expr.inspect}"
+      validate_window!(cron, cron_expr, from, to)
+
       id = @schedules.size
       name ||= "#{id} (#{cron_expr})"
-      @schedules[id] = Schedule.new(id:, name:, cron_expr:, cron:, block:)
+      @schedules[id] = Schedule.new(id:, name:, cron_expr:, cron:, from:, to:, block:)
       self
     end
 
@@ -126,6 +148,7 @@ module Sidereal
       store = @store || Sidereal.store
 
       @schedules.each_value do |sch|
+        next unless sch.active_at?(now)
         next_at = sch.cron.next_time(baseline).to_local_time
         next if next_at > now
 
@@ -145,6 +168,32 @@ module Sidereal
     end
 
     private
+
+    # nil → nil; Time → passthrough; DateTime → .to_time; String → ISO8601 parse.
+    def coerce_time(v)
+      case v
+      when nil    then nil
+      when Time   then v
+      when String then Time.parse(v)
+      else
+        return v.to_time if v.respond_to?(:to_time)
+
+        raise ArgumentError, "expected Time, DateTime, or ISO8601 String; got #{v.inspect}"
+      end
+    end
+
+    # When both bounds are present, the cron must fire at least once
+    # inside the window. Open-ended ranges (only one bound or none)
+    # are not validated — they always contain some firing.
+    def validate_window!(cron, cron_expr, from, to)
+      return unless from && to
+
+      next_fire = cron.next_time(from).to_local_time
+      return if next_fire <= to
+
+      raise ArgumentError,
+            "cron #{cron_expr.inspect} never fires inside the window [#{from.iso8601}, #{to.iso8601}]"
+    end
 
     def spawn_tick_fiber(task)
       return if @tick_fiber

--- a/lib/sidereal/scheduler.rb
+++ b/lib/sidereal/scheduler.rb
@@ -251,6 +251,8 @@ module Sidereal
     def schedules = @schedules.dup
 
     def start(task)
+      return self unless @schedules.any?
+
       elector = @elector || Sidereal.elector
       elector.on_promote { spawn_tick_fiber(task) }
       elector.on_demote { stop_tick_fiber }

--- a/lib/sidereal/scheduler.rb
+++ b/lib/sidereal/scheduler.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require 'fugit'
+require 'async'
+
+module Sidereal
+  # In-process cron-driven message scheduler.
+  #
+  # Registered via {App.schedule} (or directly via {#schedule}). Started
+  # as a child fiber of the same top-level Async task that hosts the
+  # dispatcher and pubsub (see {Sidereal::Falcon::Environment::Service#run}).
+  #
+  # Each #tick fires schedules whose next firing falls in the half-open
+  # window +(@last_tick_at, now]+. At-most-once-per-tick — matches
+  # +crond+'s no-catch-up semantics.
+  #
+  # @example
+  #   class MyApp < Sidereal::App
+  #     schedule '5 0 * * *' do
+  #       dispatch Cleanup, foo: 'bar'
+  #     end
+  #   end
+  class Scheduler
+    DEFAULT_TICK_INTERVAL = 1.0
+
+    # One per cron firing. Holds the firing-specific state and exposes
+    # +dispatch+ as the user-facing DSL — the user's block is invoked
+    # via +instance_exec+ on the Run.
+    class Run
+      attr_reader :fire_at
+
+      def initialize(schedule:, fire_at:, store:)
+        @schedule = schedule
+        @fire_at = fire_at
+        @store = store
+      end
+
+      def cron_expr = @schedule.cron_expr
+
+      def call
+        instance_exec(&@schedule.block)
+      end
+
+      def dispatch(*args)
+        msg = case args
+        in [Class => c, Hash => payload]
+          validate!(c.new(payload: payload, metadata: { producer: cron_expr }))
+        in [Class => c]
+          validate!(c.new(metadata: { producer: cron_expr }))
+        in [MessageInterface => m]
+          # +with_metadata+ uses defaults for missing attributes, which can
+          # mask an invalid input. Validate before merging.
+          validate!(m).with_metadata(producer: cron_expr)
+        end
+        @store.append(msg)
+      end
+
+      private
+
+      def validate!(msg)
+        raise Plumb::ParseError, msg.errors.inspect unless msg.valid?
+        msg
+      end
+    end
+
+    # Pure data — never mutated for the life of the process.
+    Schedule = Data.define(:cron_expr, :cron, :block) do
+      def resolve(after:, store:)
+        Run.new(schedule: self, fire_at: cron.next_time(after).to_local_time, store: store)
+      end
+    end
+
+    def initialize(tick_interval: DEFAULT_TICK_INTERVAL, clock: -> { Time.now }, store: nil)
+      @tick_interval = tick_interval
+      @clock = clock
+      @store = store
+      @schedules = []
+      @last_tick_at = nil
+    end
+
+    # Register a cron-scheduled block. Idempotency on duplicate
+    # +(expr, block)+ pairs is not enforced — callers register once at
+    # boot.
+    #
+    # @param cron_expr [String] cron expression (5 or 6 fields)
+    # @return [self]
+    def schedule(cron_expr, &block)
+      cron = Fugit.parse_cron(cron_expr) or raise ArgumentError, "invalid cron: #{cron_expr.inspect}"
+      @schedules << Schedule.new(cron_expr: cron_expr, cron: cron, block: block)
+      self
+    end
+
+    # @return [Array<Schedule>] copy of the registered schedules
+    def schedules = @schedules.dup
+
+    # Spawn the tick fiber as a child of +task+. Mirrors
+    # {Sidereal::Dispatcher.start} — returns self.
+    def start(task)
+      task.async do
+        loop do
+          tick
+          sleep @tick_interval
+        end
+      end
+      self
+    end
+
+    # Fire any schedule whose next firing falls in +(@last_tick_at, now]+.
+    # Public so unit tests can drive ticks with an injected clock.
+    def tick
+      now = @clock.call
+      baseline = @last_tick_at || now
+      store = @store || Sidereal.store
+
+      @schedules.each do |sch|
+        run = sch.resolve(after: baseline, store: store)
+        fire(run) if run.fire_at <= now
+      end
+
+      @last_tick_at = now
+    end
+
+    private
+
+    def fire(run)
+      run.call
+    rescue StandardError => ex
+      Console.error(self, 'scheduled block raised', cron: run.cron_expr, exception: ex)
+    end
+  end
+end

--- a/lib/sidereal/scheduler.rb
+++ b/lib/sidereal/scheduler.rb
@@ -51,7 +51,7 @@ module Sidereal
       @clock = clock
       @store = store
       @elector = elector            # nil = resolve from Sidereal.elector at start time
-      @schedules = []
+      @schedules = {}               # id => Schedule, insertion order = registration order
       @last_tick_at = nil
       @tick_fiber = nil
     end
@@ -66,18 +66,16 @@ module Sidereal
     def schedule(cron_expr, &block)
       cron = Fugit.parse_cron(cron_expr) or raise ArgumentError, "invalid cron: #{cron_expr.inspect}"
       id = @schedules.size
-      @schedules << Schedule.new(id:, cron_expr:, cron:, block:)
+      @schedules[id] = Schedule.new(id:, cron_expr:, cron:, block:)
       self
     end
 
-    # @return [Array<Schedule>] copy of the registered schedules
-    def schedules = @schedules.dup
+    # @return [Array<Schedule>] registered schedules in registration order
+    def schedules = @schedules.values
 
-    # Look up a registered schedule by its integer ID.
+    # Look up a registered schedule by its integer ID. O(1) hash lookup.
     # @return [Schedule, nil]
-    def find(id)
-      @schedules.find { |s| s.id == id }
-    end
+    def find(id) = @schedules[id]
 
     # Wire the tick fiber's lifecycle to the elector: spawn when this
     # process is leader, stop when demoted. With the default
@@ -99,7 +97,7 @@ module Sidereal
       baseline = @last_tick_at || now
       store = @store || Sidereal.store
 
-      @schedules.each do |sch|
+      @schedules.each_value do |sch|
         next_at = sch.cron.next_time(baseline).to_local_time
         next if next_at > now
 
@@ -111,7 +109,7 @@ module Sidereal
             )
           )
         rescue StandardError => ex
-          Console.error(self, 'failed to dispatch TriggerSchedule', schedule_id: sch.id, exception: ex)
+          Console.error(self, 'failed to dispatch TriggerSchedule', schedule_name: sch.name, exception: ex)
         end
       end
 

--- a/lib/sidereal/scheduler.rb
+++ b/lib/sidereal/scheduler.rb
@@ -22,9 +22,6 @@ module Sidereal
     DEFAULT_TICK_INTERVAL = 1.0
 
     class Schedule
-      NO_ARG = Object.new.freeze
-      private_constant :NO_ARG
-
       module Step
         # A specific instant to fire +klass+ once. +klass+ may be
         # +nil+, in which case the step is a bound-only marker (anchors
@@ -108,41 +105,38 @@ module Sidereal
 
         raise ArgumentError, "schedule #{@name.inspect}: must declare at least one at(...)" if @raw_steps.empty?
 
-        resolved = []
-        last_concrete = baseline
-        pending_recurring_idx = nil
+        walk = Walk.new(baseline: baseline, last_concrete: baseline)
+        @raw_steps.each_with_index { |raw, i| resolve_step(raw, i, walk) }
 
-        @raw_steps.each_with_index do |raw, i|
-          step, last_concrete, pending_recurring_idx =
-            resolve_step(raw, i, baseline, last_concrete, pending_recurring_idx, resolved)
-          resolved << step
-        end
-
-        @steps = resolved.freeze
-        @baseline_used = baseline
+        @steps = walk.resolved.freeze
+        @raw_steps = nil   # release the registration buffer for GC
         freeze
         self
       end
 
       private
 
-      # @return [Array(Step, last_concrete, pending_recurring_idx)] the
-      #   resolved step plus updated walk state.
-      def resolve_step(raw, idx, baseline, last_concrete, pending_recurring_idx, resolved)
+      # Mutable state threaded through the resolution walk.
+      Walk = Struct.new(:baseline, :last_concrete, :pending_recurring_idx, :resolved, keyword_init: true) do
+        def initialize(**kwargs)
+          super
+          self.resolved ||= []
+        end
+      end
+      private_constant :Walk
+
+      def resolve_step(raw, idx, walk)
         parsed = parse_expression(raw[:expression], idx)
 
         case parsed
         when Fugit::Duration
-          t = parsed.add_to_time(last_concrete).to_local_time
-          if t <= last_concrete
+          t = parsed.add_to_time(walk.last_concrete).to_local_time
+          if t <= walk.last_concrete
             raise ArgumentError,
                   "schedule #{@name.inspect}: step ##{idx} (#{raw[:expression].inspect}) resolves to " \
-                  "#{t.iso8601}, not after the previous concrete time #{last_concrete.iso8601}"
+                  "#{t.iso8601}, not after the previous concrete time #{walk.last_concrete.iso8601}"
           end
-          close_pending_recurring!(resolved, pending_recurring_idx, t)
-          step = Step::Specific.new(index: idx, expression: raw[:expression], at: t,
-                                    klass: raw[:klass], payload: raw[:payload])
-          [step, t, nil]
+          add_concrete_step!(walk, idx, raw, t)
 
         when EtOrbi::EoTime
           t = parsed.to_local_time
@@ -150,15 +144,12 @@ module Sidereal
           # actually advanced last_concrete past baseline. The very
           # first user step is allowed to be in the past — it simply
           # never fires.
-          if last_concrete > baseline && t <= last_concrete
+          if walk.last_concrete > walk.baseline && t <= walk.last_concrete
             raise ArgumentError,
                   "schedule #{@name.inspect}: specific time at step ##{idx} (#{t.iso8601}) " \
-                  "must be after the previous concrete time (#{last_concrete.iso8601})"
+                  "must be after the previous concrete time (#{walk.last_concrete.iso8601})"
           end
-          close_pending_recurring!(resolved, pending_recurring_idx, t)
-          step = Step::Specific.new(index: idx, expression: raw[:expression], at: t,
-                                    klass: raw[:klass], payload: raw[:payload])
-          [step, t, nil]
+          add_concrete_step!(walk, idx, raw, t)
 
         else
           unless parsed.respond_to?(:next_time)
@@ -171,17 +162,32 @@ module Sidereal
                   "schedule #{@name.inspect}: recurring step ##{idx} (#{raw[:expression].inspect}) " \
                   'requires a command class — bound-only markers are only meaningful for specific or duration steps'
           end
-          if pending_recurring_idx
+          if walk.pending_recurring_idx
             raise ArgumentError,
                   "schedule #{@name.inspect}: step ##{idx} (#{raw[:expression].inspect}) is recurring " \
-                  "but the previous step (##{pending_recurring_idx}) is also recurring with no closing bound. " \
+                  "but the previous step (##{walk.pending_recurring_idx}) is also recurring with no closing bound. " \
                   'A concrete (specific or duration) step must separate two recurring steps.'
           end
-          step = Step::Recurring.new(index: idx, expression: raw[:expression], cron: parsed,
-                                     from: last_concrete, to: nil,
-                                     klass: raw[:klass], payload: raw[:payload])
-          [step, last_concrete, idx]
+          walk.resolved << Step::Recurring.new(
+            index: idx, expression: raw[:expression], cron: parsed,
+            from: walk.last_concrete, to: nil,
+            klass: raw[:klass], payload: raw[:payload]
+          )
+          walk.pending_recurring_idx = idx
         end
+      end
+
+      # Append a concrete (specific or duration-resolved) step,
+      # closing any pending recurring step at the same instant and
+      # advancing the +last_concrete+ cursor.
+      def add_concrete_step!(walk, idx, raw, t)
+        close_pending_recurring!(walk, t)
+        walk.resolved << Step::Specific.new(
+          index: idx, expression: raw[:expression], at: t,
+          klass: raw[:klass], payload: raw[:payload]
+        )
+        walk.last_concrete = t
+        walk.pending_recurring_idx = nil
       end
 
       # Coerce the user-supplied expression into something the
@@ -208,15 +214,12 @@ module Sidereal
       end
 
       # Close the pending recurring step (if any) by replacing it in
-      # +resolved+ with a copy whose +to+ is set to +t+.
-      def close_pending_recurring!(resolved, pending_recurring_idx, t)
-        return if pending_recurring_idx.nil?
+      # +walk.resolved+ with a copy whose +to+ is set to +t+.
+      def close_pending_recurring!(walk, t)
+        idx = walk.pending_recurring_idx
+        return if idx.nil?
 
-        prev = resolved[pending_recurring_idx]
-        resolved[pending_recurring_idx] = Step::Recurring.new(
-          index: prev.index, expression: prev.expression, cron: prev.cron,
-          from: prev.from, to: t, klass: prev.klass, payload: prev.payload
-        )
+        walk.resolved[idx] = walk.resolved[idx].with(to: t)
       end
     end
 

--- a/lib/sidereal/scheduler.rb
+++ b/lib/sidereal/scheduler.rb
@@ -232,6 +232,10 @@ module Sidereal
       @store = store
       @elector = elector
       @schedules = []
+      # Frozen +{ producer:, schedule_name: }+ hash precomputed per
+      # step at registration. Identity-keyed because two Data records
+      # with identical fields would otherwise collide on +eql?+.
+      @step_metadata = {}.compare_by_identity
       @last_tick_at = nil
       @tick_fiber = nil
     end
@@ -247,7 +251,9 @@ module Sidereal
             end
       yield(sch) if block_given?
       sch.finalize!(baseline: @baseline)
+      schedule_id = @schedules.size
       @schedules << sch
+      cache_step_metadata!(sch, schedule_id)
       self
     end
 
@@ -267,12 +273,11 @@ module Sidereal
       baseline = @last_tick_at || now
       store = @store || Sidereal.store
 
-      @schedules.each_with_index do |sch, schedule_id|
+      @schedules.each do |sch|
         sch.steps.each do |step|
           next unless step.fires_in?(baseline, now)
 
-          metadata = build_metadata(sch, schedule_id, step)
-          dispatch(store, step, metadata)
+          dispatch(store, step, @step_metadata[step])
         end
       end
 
@@ -281,11 +286,13 @@ module Sidereal
 
     private
 
-    def build_metadata(sch, schedule_id, step)
-      {
-        producer: producer_label(schedule_id, sch, step),
-        schedule_name: sch.name
-      }
+    def cache_step_metadata!(sch, schedule_id)
+      sch.steps.each do |step|
+        @step_metadata[step] = {
+          producer: producer_label(schedule_id, sch, step),
+          schedule_name: sch.name
+        }.freeze
+      end
     end
 
     def producer_label(schedule_id, sch, step)

--- a/lib/sidereal/scheduler.rb
+++ b/lib/sidereal/scheduler.rb
@@ -34,9 +34,19 @@ module Sidereal
     # Pure data — never mutated for the life of the process. The +id+
     # is a stable monotonic integer assigned by {Scheduler#schedule}
     # in registration order, used by +TriggerSchedule.payload.schedule_id+
-    # to look the schedule back up at handle time.
-    Schedule = Data.define(:id, :cron_expr, :cron, :block) do
-      def name = "Schedule ##{id} (#{cron_expr})"
+    # to look the schedule back up at handle time. The +name+ is
+    # user-supplied at registration ("Recurring cleanup", etc.) and
+    # surfaced on +TriggerSchedule.payload.schedule_name+ and inside
+    # the +producer+ metadata hash so dispatched commands carry a
+    # readable trail back to the originating schedule.
+    Schedule = Data.define(:id, :name, :cron_expr, :cron, :block) do
+      # Human-readable identifier stamped on +TriggerSchedule.metadata[:producer]+
+      # and inherited by every command dispatched from the schedule
+      # block via +Message#correlate+. Single-line string so it can sit
+      # comfortably in logs, dead-letter sidecars, and chat messages.
+      def producer_label
+        "Schedule ##{id} '#{name}' (#{cron_expr})"
+      end
 
       # Execute the schedule's block on +context+ via instance_exec, so
       # the block sees +context+'s methods (typically a Commander
@@ -66,12 +76,25 @@ module Sidereal
     # cron expression — each gets its own ID and its own
     # +TriggerSchedule+ on every fire.
     #
-    # @param cron_expr [String] cron expression (5 or 6 fields)
+    # Two call shapes:
+    # - +schedule(cron_expr) { ... }+ — auto-named as +"<id> (<cron_expr>)"+
+    # - +schedule(name, cron_expr) { ... }+ — user-supplied name
+    #
     # @return [self]
-    def schedule(cron_expr, &block)
+    def schedule(*args, &block)
+      name, cron_expr = case args
+      in [String => cron_expr]
+        [nil, cron_expr]
+      in [String => name, String => cron_expr]
+        [name, cron_expr]
+      else
+        raise ArgumentError, "schedule takes (cron_expr) or (name, cron_expr); got #{args.inspect}"
+      end
+
       cron = Fugit.parse_cron(cron_expr) or raise ArgumentError, "invalid cron: #{cron_expr.inspect}"
       id = @schedules.size
-      @schedules[id] = Schedule.new(id:, cron_expr:, cron:, block:)
+      name ||= "#{id} (#{cron_expr})"
+      @schedules[id] = Schedule.new(id:, name:, cron_expr:, cron:, block:)
       self
     end
 
@@ -109,8 +132,8 @@ module Sidereal
         begin
           store.append(
             Sidereal::System::TriggerSchedule.new(
-              payload: { schedule_id: sch.id },
-              metadata: { producer: sch.name }
+              payload: { schedule_id: sch.id, schedule_name: sch.name },
+              metadata: { producer: sch.producer_label }
             )
           )
         rescue StandardError => ex

--- a/lib/sidereal/scheduler.rb
+++ b/lib/sidereal/scheduler.rb
@@ -10,9 +10,17 @@ module Sidereal
   # as a child fiber of the same top-level Async task that hosts the
   # dispatcher and pubsub (see {Sidereal::Falcon::Environment::Service#run}).
   #
-  # Each #tick fires schedules whose next firing falls in the half-open
-  # window +(@last_tick_at, now]+. At-most-once-per-tick — matches
-  # +crond+'s no-catch-up semantics.
+  # On each #tick the scheduler walks its registered schedules. For
+  # each whose next firing falls in the half-open window
+  # +(@last_tick_at, now]+, it dispatches a
+  # {Sidereal::System::TriggerSchedule} command into the store. The
+  # dispatcher's worker pool — possibly multi-process — claims those
+  # commands and runs the schedule's block in a Commander instance via
+  # {Schedule#run_in}. This keeps the scheduler tick fiber doing
+  # almost no work and lets schedule blocks run in parallel under the
+  # standard retry/dead-letter machinery.
+  #
+  # At-most-once-per-tick — matches +crond+'s no-catch-up semantics.
   #
   # @example
   #   class MyApp < Sidereal::App
@@ -23,50 +31,16 @@ module Sidereal
   class Scheduler
     DEFAULT_TICK_INTERVAL = 1.0
 
-    # One per cron firing. Holds the firing-specific state and exposes
-    # +dispatch+ as the user-facing DSL — the user's block is invoked
-    # via +instance_exec+ on the Run.
-    class Run
-      attr_reader :fire_at
-
-      def initialize(schedule:, fire_at:, store:)
-        @schedule = schedule
-        @fire_at = fire_at
-        @store = store
-      end
-
-      def cron_expr = @schedule.cron_expr
-
-      def call
-        instance_exec(&@schedule.block)
-      end
-
-      def dispatch(*args)
-        msg = case args
-        in [Class => c, Hash => payload]
-          validate!(c.new(payload: payload, metadata: { producer: cron_expr }))
-        in [Class => c]
-          validate!(c.new(metadata: { producer: cron_expr }))
-        in [MessageInterface => m]
-          # +with_metadata+ uses defaults for missing attributes, which can
-          # mask an invalid input. Validate before merging.
-          validate!(m).with_metadata(producer: cron_expr)
-        end
-        @store.append(msg)
-      end
-
-      private
-
-      def validate!(msg)
-        raise Plumb::ParseError, msg.errors.inspect unless msg.valid?
-        msg
-      end
-    end
-
-    # Pure data — never mutated for the life of the process.
-    Schedule = Data.define(:cron_expr, :cron, :block) do
-      def resolve(after:, store:)
-        Run.new(schedule: self, fire_at: cron.next_time(after).to_local_time, store: store)
+    # Pure data — never mutated for the life of the process. The +id+
+    # is a stable monotonic integer assigned by {Scheduler#schedule}
+    # in registration order, used by +TriggerSchedule.payload.schedule_id+
+    # to look the schedule back up at handle time.
+    Schedule = Data.define(:id, :cron_expr, :cron, :block) do
+      # Execute the schedule's block on +context+ via instance_exec, so
+      # the block sees +context+'s methods (typically a Commander
+      # instance, exposing +dispatch+, +broadcast+, +pubsub+, etc.).
+      def run_in(context)
+        context.instance_exec(&block)
       end
     end
 
@@ -80,20 +54,28 @@ module Sidereal
       @tick_fiber = nil
     end
 
-    # Register a cron-scheduled block. Idempotency on duplicate
-    # +(expr, block)+ pairs is not enforced — callers register once at
-    # boot.
+    # Register a cron-scheduled block. The schedule is assigned the
+    # next monotonic integer ID. Multiple blocks may share the same
+    # cron expression — each gets its own ID and its own
+    # +TriggerSchedule+ on every fire.
     #
     # @param cron_expr [String] cron expression (5 or 6 fields)
     # @return [self]
     def schedule(cron_expr, &block)
       cron = Fugit.parse_cron(cron_expr) or raise ArgumentError, "invalid cron: #{cron_expr.inspect}"
-      @schedules << Schedule.new(cron_expr: cron_expr, cron: cron, block: block)
+      id = @schedules.size
+      @schedules << Schedule.new(id:, cron_expr:, cron:, block:)
       self
     end
 
     # @return [Array<Schedule>] copy of the registered schedules
     def schedules = @schedules.dup
+
+    # Look up a registered schedule by its integer ID.
+    # @return [Schedule, nil]
+    def find(id)
+      @schedules.find { |s| s.id == id }
+    end
 
     # Wire the tick fiber's lifecycle to the elector: spawn when this
     # process is leader, stop when demoted. With the default
@@ -107,28 +89,34 @@ module Sidereal
       self
     end
 
-    # Fire any schedule whose next firing falls in +(@last_tick_at, now]+.
-    # Public so unit tests can drive ticks with an injected clock.
+    # For each schedule whose next firing falls in +(@last_tick_at, now]+,
+    # dispatch a +TriggerSchedule+ to the store. Public so unit tests
+    # can drive ticks with an injected clock.
     def tick
       now = @clock.call
       baseline = @last_tick_at || now
       store = @store || Sidereal.store
 
       @schedules.each do |sch|
-        run = sch.resolve(after: baseline, store: store)
-        fire(run) if run.fire_at <= now
+        next_at = sch.cron.next_time(baseline).to_local_time
+        next if next_at > now
+
+        begin
+          store.append(
+            Sidereal::System::TriggerSchedule.new(
+              payload: { schedule_id: sch.id },
+              metadata: { producer: sch.cron_expr }
+            )
+          )
+        rescue StandardError => ex
+          Console.error(self, 'failed to dispatch TriggerSchedule', schedule_id: sch.id, exception: ex)
+        end
       end
 
       @last_tick_at = now
     end
 
     private
-
-    def fire(run)
-      run.call
-    rescue StandardError => ex
-      Console.error(self, 'scheduled block raised', cron: run.cron_expr, exception: ex)
-    end
 
     def spawn_tick_fiber(task)
       return if @tick_fiber

--- a/lib/sidereal/scheduler.rb
+++ b/lib/sidereal/scheduler.rb
@@ -1,73 +1,219 @@
 # frozen_string_literal: true
 
-require 'time'   # Time.iso8601
+require 'time'   # Time.iso8601, Time.parse
 require 'fugit'
 require 'async'
 
 module Sidereal
-  # In-process cron-driven message scheduler.
+  # In-process cron-driven message dispatcher.
   #
-  # Registered via {App.schedule} (or directly via {#schedule}). Started
-  # as a child fiber of the same top-level Async task that hosts the
-  # dispatcher and pubsub (see {Sidereal::Falcon::Environment::Service#run}).
+  # Each registered {Schedule} holds:
+  # - a parsed expression (cron or natural-language, via +Fugit.parse+),
+  # - an optional human-readable +name+,
+  # - up to three role specs ({Schedule::RoleSpec}) — +run+ (required),
+  #   +enter+ (optional), +exit+ (optional) — each pairing a Message
+  #   class with a static payload Hash,
+  # - optional +enter_at+ and +exit_at+ wall-clock bounds.
   #
-  # On each #tick the scheduler walks its registered schedules. For
-  # each whose next firing falls in the half-open window
-  # +(@last_tick_at, now]+, it dispatches a
-  # {Sidereal::System::TriggerSchedule} command into the store. The
-  # dispatcher's worker pool — possibly multi-process — claims those
-  # commands and runs the schedule's block in a Commander instance via
-  # {Schedule#run_in}. This keeps the scheduler tick fiber doing
-  # almost no work and lets schedule blocks run in parallel under the
-  # standard retry/dead-letter machinery.
+  # On each tick, the Scheduler:
+  # - dispatches the +enter+ command iff its instant falls in
+  #   +(@last_tick_at, now]+;
+  # - dispatches the +exit+ command iff its instant falls in
+  #   +(@last_tick_at, now]+;
+  # - **otherwise** dispatches the +run+ command iff a cron boundary
+  #   falls in the window and the schedule is active at +now+.
   #
-  # At-most-once-per-tick — matches +crond+'s no-catch-up semantics.
+  # The "otherwise" is deliberate: when a tick fires +enter+ (or
+  # +exit+), we skip +run+ on that same tick so commands handled
+  # asynchronously can be ordered correctly — enter strictly before
+  # any run, exit strictly after.
   #
-  # @example
-  #   class MyApp < Sidereal::App
-  #     schedule '5 0 * * *' do
-  #       dispatch Cleanup, foo: 'bar'
-  #     end
-  #   end
+  # The Scheduler computes +metadata: { producer:, schedule_name: }+
+  # at firing time and dispatches via +klass.parse(payload:, metadata:)+
+  # — making no assumption about the message's payload schema and
+  # avoiding the Message registry entirely.
   class Scheduler
     DEFAULT_TICK_INTERVAL = 1.0
 
-    # Pure data — never mutated for the life of the process. The +id+
-    # is a stable monotonic integer assigned by {Scheduler#schedule}
-    # in registration order, used by +TriggerSchedule.payload.schedule_id+
-    # to look the schedule back up at handle time. The +name+ is
-    # user-supplied at registration ("Recurring cleanup", etc.) and
-    # surfaced on +TriggerSchedule.payload.schedule_name+ and inside
-    # the +producer+ metadata hash so dispatched commands carry a
-    # readable trail back to the originating schedule.
-    Schedule = Data.define(:id, :name, :cron_expr, :cron, :from, :to, :block) do
-      # Human-readable identifier stamped on +TriggerSchedule.metadata[:producer]+
-      # and inherited by every command dispatched from the schedule
-      # block via +Message#correlate+. Single-line string so it can sit
-      # comfortably in logs, dead-letter sidecars, and chat messages.
-      def producer_label
-        "Schedule ##{id} '#{name}' (#{cron_expr})"
+    # Schedule builder. Mutable until {Scheduler#schedule} calls
+    # {#finalize!}, after which it's frozen.
+    class Schedule
+      RoleSpec = Data.define(:klass, :payload)
+      NO_ARG = Object.new.freeze
+      private_constant :NO_ARG
+
+      # +Fugit.parse+ returns +EtOrbi::EoTime+ for ISO8601 / date
+      # strings — a single instant with no +next_time+. Wrap it so the
+      # tick loop sees a uniform "+#next_time(from)+ → Time | nil"
+      # interface across cron and one-off expressions.
+      class OneOff
+        # Wrap +at+ as something responding to +#to_local_time+ so the
+        # tick-loop's normalization is uniform. +Fugit.parse+ already
+        # returns +EtOrbi::EoTime+ for date strings; for stdlib +Time+
+        # passed in directly we build an EoTime via +EtOrbi::EoTime.make+.
+        def initialize(at)
+          @at = if at.respond_to?(:to_local_time)
+                  at
+                else
+                  EtOrbi::EoTime.make(at)
+                end
+        end
+
+        def next_time(from)
+          return nil if @at < from
+
+          @at
+        end
+      end
+      private_constant :OneOff
+
+      attr_reader :name, :expression, :cron, :enter, :exit
+
+      def initialize(name)
+        raise ArgumentError, 'schedule name is required' if name.nil? || name.to_s.empty?
+
+        @name = name
+        @expression = nil
+        @cron = nil
+        @run = nil
+        @enter = nil
+        @exit = nil
+        @enter_at = nil
+        @exit_at = nil
+        @exit_at_relative_resolver = nil
+        @exit_at_relative_kind = nil
       end
 
-      # Whether this schedule should be considered for firing at +time+.
-      # Bounds are inclusive on both ends. Returns +true+ when no
-      # bounds are set (the common case).
+      # Recurring (or one-off) schedule expression + the command to
+      # dispatch at each firing. The expression is anything
+      # +Fugit.parse+ accepts — cron strings, natural-language
+      # ("every 3 seconds"), or an ISO8601 date for a one-off.
+      #
+      # With no args, returns the current run +RoleSpec+ (or nil).
+      def run_at(expression = NO_ARG, klass = NO_ARG, **payload)
+        return @run if expression.equal?(NO_ARG)
+        raise ArgumentError, 'run_at requires a command class' if klass.equal?(NO_ARG)
+
+        @expression = expression
+        parsed = Fugit.parse(expression) or raise ArgumentError, "invalid schedule expression: #{expression.inspect}"
+        # Cron / interval objects implement #next_time directly; date
+        # strings parse to EtOrbi::EoTime (a one-off instant) which
+        # we wrap.
+        @cron = parsed.respond_to?(:next_time) ? parsed : OneOff.new(parsed)
+
+        @run = RoleSpec.new(klass: klass, payload: payload)
+        self
+      end
+
+      # @return [RoleSpec, nil] the recurring command spec
+      def run = @run
+
+      def enter_at(time = NO_ARG, klass = nil, **payload)
+        return @enter_at if time.equal?(NO_ARG)
+
+        @enter_at = coerce_time(time)
+        @enter = klass ? RoleSpec.new(klass: klass, payload: payload) : nil
+        self
+      end
+
+      # exit_at accepts:
+      # - a +Time+, +DateTime+, or absolute ISO8601 string — evaluated as-is.
+      # - a callable (proc/lambda/method) — invoked at finalize with
+      #   the resolved +enter_at+.
+      # - an ISO8601 duration string ("P12Y12M") or Fugit duration
+      #   ("12y12M", "1h30m", "90s") — added to the resolved
+      #   +enter_at+ at finalize.
+      #
+      # Callable and duration forms both *require* +enter_at+ and
+      # raise a guidance-rich error at finalize when it's missing.
+      def exit_at(value = NO_ARG, klass = nil, **payload)
+        return @exit_at if value.equal?(NO_ARG)
+
+        resolver, kind = relative_exit_at(value)
+        if resolver
+          @exit_at_relative_resolver = resolver
+          @exit_at_relative_kind = kind
+        else
+          @exit_at = coerce_time(value)
+        end
+        @exit = klass ? RoleSpec.new(klass: klass, payload: payload) : nil
+        self
+      end
+
+      # Resolve relative +exit_at+ (callable or duration), validate
+      # the window, and freeze. Idempotent.
+      def finalize!
+        return self if frozen?
+
+        raise ArgumentError, 'schedule run_at is required' unless @run
+
+        if @exit_at_relative_resolver
+          unless @enter_at
+            kind = @exit_at_relative_kind
+            raise ArgumentError,
+                  "schedule #{@name.inspect}: exit_at was given a #{kind} but no enter_at is set. " \
+                  "#{kind.capitalize}s are resolved relative to enter_at; either declare enter_at, " \
+                  'or pass a static Time/String/DateTime to exit_at.'
+          end
+
+          @exit_at = coerce_time(@exit_at_relative_resolver.call(@enter_at))
+        end
+
+        validate_window!
+        freeze
+        self
+      end
+
       def active_at?(time)
-        return false if from && time < from
-        return false if to   && time > to
+        return false if @enter_at && time < @enter_at
+        return false if @exit_at  && time > @exit_at
+
         true
       end
 
-      # Execute the schedule's block on +context+ via instance_exec, so
-      # the block sees +context+'s methods (typically a Commander
-      # instance, exposing +dispatch+, +broadcast+, +pubsub+, etc.).
-      # The triggering +cmd+ (the +TriggerSchedule+ being handled) is
-      # yielded as the block's argument, so the block can read its
-      # +metadata+ (e.g. +cmd.metadata[:producer]+) or +id+ for
-      # idempotency keys. Blocks that don't declare a parameter
-      # silently discard +cmd+ (proc semantics).
-      def run_in(context, cmd)
-        context.instance_exec(cmd, &block)
+      private
+
+      # Detect whether +value+ is a relative exit_at form (callable or
+      # a Fugit-parseable duration string). Returns +[resolver_proc,
+      # kind]+ or nil. Each resolver, when given the resolved
+      # +enter_at+, returns a Time-like (Time, EoTime, DateTime).
+      def relative_exit_at(value)
+        if value.respond_to?(:call) && !value.is_a?(Time)
+          [value, 'callable']
+        elsif value.is_a?(String) && (duration = parse_duration(value))
+          [->(enter_at) { duration.add_to_time(enter_at) }, 'duration']
+        end
+      end
+
+      # @return [Fugit::Duration, nil] the parsed duration, or nil if
+      #   the string isn't a duration expression.
+      def parse_duration(str)
+        parsed = Fugit.parse(str)
+        parsed.is_a?(Fugit::Duration) ? parsed : nil
+      end
+
+      def coerce_time(v)
+        case v
+        when nil    then nil
+        when Time   then v
+        when String then Time.parse(v)
+        else
+          # EtOrbi::EoTime → to_local_time; DateTime → to_time.
+          return v.to_local_time if v.respond_to?(:to_local_time)
+          return v.to_time       if v.respond_to?(:to_time)
+
+          raise ArgumentError, "expected Time, DateTime, or ISO8601 String; got #{v.inspect}"
+        end
+      end
+
+      def validate_window!
+        return unless @enter_at && @exit_at
+
+        next_fire = @cron.next_time(@enter_at)&.to_local_time
+        return if next_fire && next_fire <= @exit_at
+
+        raise ArgumentError,
+              "schedule run #{@expression.inspect} ('#{@name}') never fires inside the window [#{@enter_at.iso8601}, #{@exit_at.iso8601}]"
       end
     end
 
@@ -76,62 +222,33 @@ module Sidereal
       @clock = clock
       @store = store
       @elector = elector            # nil = resolve from Sidereal.elector at start time
-      @schedules = {}               # id => Schedule, insertion order = registration order
+      @schedules = []               # registration order
       @last_tick_at = nil
       @tick_fiber = nil
     end
 
-    # Register a cron-scheduled block. The schedule is assigned the
-    # next monotonic integer ID. Multiple blocks may share the same
-    # cron expression — each gets its own ID and its own
-    # +TriggerSchedule+ on every fire.
-    #
-    # Two call shapes:
-    # - +schedule(cron_expr) { ... }+ — auto-named as +"<id> (<cron_expr>)"+
-    # - +schedule(name, cron_expr) { ... }+ — user-supplied name
-    #
-    # Optional +from:+ / +to:+ keyword arguments bound the schedule to
-    # a wall-clock window. Each accepts +nil+, a +Time+, a +DateTime+,
-    # or an ISO8601 +String+ (parsed once at registration). When both
-    # are given, the cron expression is validated to fire at least
-    # once inside the window — guarding against e.g. a daily cron
-    # paired with a sub-day window.
+    # Register a schedule. Accepts either a String name (constructs a
+    # fresh +Schedule+) or a pre-built +Schedule+ instance. The name
+    # is mandatory; empty/nil rejected at the +Schedule+ constructor.
+    # The block (when given) builds the schedule via the +Schedule+
+    # builder methods (+run_at+, +enter_at+, +exit_at+).
     #
     # @return [self]
-    def schedule(*args, from: nil, to: nil, &block)
-      name, cron_expr = case args
-      in [String => cron_expr]
-        [nil, cron_expr]
-      in [String => name, String => cron_expr]
-        [name, cron_expr]
-      else
-        raise ArgumentError, "schedule takes (cron_expr) or (name, cron_expr); got #{args.inspect}"
-      end
-
-      from = coerce_time(from)
-      to   = coerce_time(to)
-
-      cron = Fugit.parse_cron(cron_expr) or raise ArgumentError, "invalid cron: #{cron_expr.inspect}"
-      validate_window!(cron, cron_expr, from, to)
-
-      id = @schedules.size
-      name ||= "#{id} (#{cron_expr})"
-      @schedules[id] = Schedule.new(id:, name:, cron_expr:, cron:, from:, to:, block:)
+    def schedule(name_or_instance)
+      sch = case name_or_instance
+            when Schedule then name_or_instance
+            when String   then Schedule.new(name_or_instance)
+            else raise ArgumentError, "expected Schedule or String name; got #{name_or_instance.inspect}"
+            end
+      yield(sch) if block_given?
+      sch.finalize!
+      @schedules << sch
       self
     end
 
     # @return [Array<Schedule>] registered schedules in registration order
-    def schedules = @schedules.values
+    def schedules = @schedules.dup
 
-    # Look up a registered schedule by its integer ID. O(1) hash lookup.
-    # @return [Schedule, nil]
-    def find(id) = @schedules[id]
-
-    # Wire the tick fiber's lifecycle to the elector: spawn when this
-    # process is leader, stop when demoted. With the default
-    # {Elector::AlwaysLeader}, +on_promote+ fires immediately on
-    # registration and the fiber starts straight away — same behaviour
-    # as before electors existed.
     def start(task)
       elector = @elector || Sidereal.elector
       elector.on_promote { spawn_tick_fiber(task) }
@@ -139,29 +256,40 @@ module Sidereal
       self
     end
 
-    # For each schedule whose next firing falls in +(@last_tick_at, now]+,
-    # dispatch a +TriggerSchedule+ to the store. Public so unit tests
-    # can drive ticks with an injected clock.
-    def tick
-      now = @clock.call
+    # @param now [Time] explicit firing instant; defaults to +@clock.call+.
+    #   Useful in tests so you don't have to mock the clock — just pass
+    #   the time you want the tick to evaluate as.
+    def tick(now = @clock.call)
       baseline = @last_tick_at || now
       store = @store || Sidereal.store
 
-      @schedules.each_value do |sch|
-        next unless sch.active_at?(now)
-        next_at = sch.cron.next_time(baseline).to_local_time
-        next if next_at > now
+      @schedules.each_with_index do |sch, id|
+        metadata = build_metadata(sch, id)
+        enter_or_exit_fired = false
 
-        begin
-          store.append(
-            Sidereal::System::TriggerSchedule.new(
-              payload: { schedule_id: sch.id, schedule_name: sch.name },
-              metadata: { producer: sch.producer_label }
-            )
-          )
-        rescue StandardError => ex
-          Console.error(self, 'failed to dispatch TriggerSchedule', schedule_name: sch.name, exception: ex)
+        if sch.enter && bound_in_window?(sch.enter_at, baseline, now)
+          dispatch(store, sch.enter, metadata)
+          enter_or_exit_fired = true
         end
+
+        if sch.exit && bound_in_window?(sch.exit_at, baseline, now)
+          dispatch(store, sch.exit, metadata)
+          enter_or_exit_fired = true
+        end
+
+        # Skip run on the same tick that fired enter/exit so the
+        # asynchronous worker pool processes them in the desired
+        # order: enter strictly before any run, exit strictly after.
+        next if enter_or_exit_fired
+        next unless sch.active_at?(now)
+
+        # Fugit::At returns nil from +next_time+ once the at-instant has
+        # passed — guards against NPE and naturally prevents one-offs
+        # from refiring.
+        next_at = sch.cron.next_time(baseline)&.to_local_time
+        next if next_at.nil? || next_at > now
+
+        dispatch(store, sch.run, metadata)
       end
 
       @last_tick_at = now
@@ -169,30 +297,26 @@ module Sidereal
 
     private
 
-    # nil → nil; Time → passthrough; DateTime → .to_time; String → ISO8601 parse.
-    def coerce_time(v)
-      case v
-      when nil    then nil
-      when Time   then v
-      when String then Time.parse(v)
-      else
-        return v.to_time if v.respond_to?(:to_time)
-
-        raise ArgumentError, "expected Time, DateTime, or ISO8601 String; got #{v.inspect}"
-      end
+    def bound_in_window?(instant, baseline, now)
+      instant && instant > baseline && instant <= now
     end
 
-    # When both bounds are present, the cron must fire at least once
-    # inside the window. Open-ended ranges (only one bound or none)
-    # are not validated — they always contain some firing.
-    def validate_window!(cron, cron_expr, from, to)
-      return unless from && to
+    # Compute the per-firing metadata. Apps that want a different
+    # shape can override this on a Scheduler subclass.
+    def build_metadata(sch, id)
+      { producer: producer_label(id, sch), schedule_name: sch.name }
+    end
 
-      next_fire = cron.next_time(from).to_local_time
-      return if next_fire <= to
+    def producer_label(id, sch)
+      "Schedule ##{id} '#{sch.name}' (#{sch.expression})"
+    end
 
-      raise ArgumentError,
-            "cron #{cron_expr.inspect} never fires inside the window [#{from.iso8601}, #{to.iso8601}]"
+    def dispatch(store, role_spec, metadata)
+      msg = role_spec.klass.parse(payload: role_spec.payload, metadata: metadata)
+      store.append(msg)
+    rescue StandardError => ex
+      Console.error(self, 'failed to dispatch scheduled command',
+                    klass: role_spec.klass.name, exception: ex)
     end
 
     def spawn_tick_fiber(task)
@@ -210,9 +334,6 @@ module Sidereal
       f = @tick_fiber
       @tick_fiber = nil
       f&.stop
-      # Reset cursor so the next promotion starts a fresh window — without
-      # this, a long demotion would cause a one-shot fire on re-promotion
-      # for any cron whose boundary fell during the demotion.
       @last_tick_at = nil
     end
   end

--- a/lib/sidereal/scheduler.rb
+++ b/lib/sidereal/scheduler.rb
@@ -41,8 +41,13 @@ module Sidereal
       # Execute the schedule's block on +context+ via instance_exec, so
       # the block sees +context+'s methods (typically a Commander
       # instance, exposing +dispatch+, +broadcast+, +pubsub+, etc.).
-      def run_in(context)
-        context.instance_exec(&block)
+      # The triggering +cmd+ (the +TriggerSchedule+ being handled) is
+      # yielded as the block's argument, so the block can read its
+      # +metadata+ (e.g. +cmd.metadata[:producer]+) or +id+ for
+      # idempotency keys. Blocks that don't declare a parameter
+      # silently discard +cmd+ (proc semantics).
+      def run_in(context, cmd)
+        context.instance_exec(cmd, &block)
       end
     end
 

--- a/lib/sidereal/scheduler.rb
+++ b/lib/sidereal/scheduler.rb
@@ -1,239 +1,241 @@
 # frozen_string_literal: true
 
-require 'time'   # Time.iso8601, Time.parse
+require 'time'   # Time.parse, Time.iso8601
 require 'fugit'
 require 'async'
 
 module Sidereal
-  # In-process cron-driven message dispatcher.
+  # In-process step-sequence dispatcher.
   #
-  # Each registered {Schedule} holds:
-  # - a parsed expression (cron or natural-language, via +Fugit.parse+),
-  # - an optional human-readable +name+,
-  # - up to three role specs ({Schedule::RoleSpec}) — +run+ (required),
-  #   +enter+ (optional), +exit+ (optional) — each pairing a Message
-  #   class with a static payload Hash,
-  # - optional +enter_at+ and +exit_at+ wall-clock bounds.
+  # A {Schedule} is an ordered sequence of moments in time, each
+  # paired with a command to dispatch. A "moment" can be a specific
+  # datetime, a duration relative to the previous concrete moment, or
+  # a recurring expression that fires on every match between its
+  # start and the next concrete moment (or forever, if no concrete
+  # moment follows).
   #
-  # On each tick, the Scheduler:
-  # - dispatches the +enter+ command iff its instant falls in
-  #   +(@last_tick_at, now]+;
-  # - dispatches the +exit+ command iff its instant falls in
-  #   +(@last_tick_at, now]+;
-  # - **otherwise** dispatches the +run+ command iff a cron boundary
-  #   falls in the window and the schedule is active at +now+.
-  #
-  # The "otherwise" is deliberate: when a tick fires +enter+ (or
-  # +exit+), we skip +run+ on that same tick so commands handled
-  # asynchronously can be ordered correctly — enter strictly before
-  # any run, exit strictly after.
-  #
-  # The Scheduler computes +metadata: { producer:, schedule_name: }+
-  # at firing time and dispatches via +klass.parse(payload:, metadata:)+
-  # — making no assumption about the message's payload schema and
-  # avoiding the Message registry entirely.
+  # The Scheduler is class-agnostic: at firing time it calls
+  # +klass.parse(payload:, metadata:)+ on whatever class the user
+  # registered. No assumption about the message's payload schema and
+  # no Message-registry lookup.
   class Scheduler
     DEFAULT_TICK_INTERVAL = 1.0
 
-    # Schedule builder. Mutable until {Scheduler#schedule} calls
-    # {#finalize!}, after which it's frozen.
     class Schedule
-      RoleSpec = Data.define(:klass, :payload)
       NO_ARG = Object.new.freeze
       private_constant :NO_ARG
 
-      # +Fugit.parse+ returns +EtOrbi::EoTime+ for ISO8601 / date
-      # strings — a single instant with no +next_time+. Wrap it so the
-      # tick loop sees a uniform "+#next_time(from)+ → Time | nil"
-      # interface across cron and one-off expressions.
-      class OneOff
-        # Wrap +at+ as something responding to +#to_local_time+ so the
-        # tick-loop's normalization is uniform. +Fugit.parse+ already
-        # returns +EtOrbi::EoTime+ for date strings; for stdlib +Time+
-        # passed in directly we build an EoTime via +EtOrbi::EoTime.make+.
-        def initialize(at)
-          @at = if at.respond_to?(:to_local_time)
-                  at
-                else
-                  EtOrbi::EoTime.make(at)
-                end
+      module Step
+        # A specific instant to fire +klass+ once. +klass+ may be
+        # +nil+, in which case the step is a bound-only marker (anchors
+        # the timeline without dispatching anything).
+        Specific = Data.define(:index, :expression, :at, :klass, :payload) do
+          # Fires iff +at+ falls strictly inside +(baseline, now]+
+          # AND a +klass+ is set. Bound-only markers never fire.
+          def fires_in?(baseline, now)
+            return false if klass.nil?
+
+            at > baseline && at <= now
+          end
         end
 
-        def next_time(from)
-          return nil if @at < from
+        # A recurring expression bounded by +[from, to)+ (open at the
+        # upper end so a cron boundary at exactly +to+ belongs to the
+        # closing concrete step, not the recurring).
+        Recurring = Data.define(:index, :expression, :cron, :from, :to, :klass, :payload) do
+          def fires_in?(baseline, now)
+            return false if now < from
+            return false if to && now >= to
 
-          @at
+            window_start = baseline > from ? baseline : from
+            next_at = cron.next_time(window_start)&.to_local_time
+            return false if next_at.nil?
+            return false if next_at > now
+            return false if to && next_at >= to
+
+            true
+          end
         end
       end
-      private_constant :OneOff
 
-      attr_reader :name, :expression, :cron, :enter, :exit
+      attr_reader :name, :steps
 
       def initialize(name)
         raise ArgumentError, 'schedule name is required' if name.nil? || name.to_s.empty?
 
         @name = name
-        @expression = nil
-        @cron = nil
-        @run = nil
-        @enter = nil
-        @exit = nil
-        @enter_at = nil
-        @exit_at = nil
-        @exit_at_relative_resolver = nil
-        @exit_at_relative_kind = nil
+        @raw_steps = []
+        @steps = nil
       end
 
-      # Recurring (or one-off) schedule expression + the command to
-      # dispatch at each firing. The expression is anything
-      # +Fugit.parse+ accepts — cron strings, natural-language
-      # ("every 3 seconds"), or an ISO8601 date for a one-off.
+      # Append a step. Three expression kinds, distinguished by
+      # +Fugit.parse+ at finalize:
+      # - specific datetime → fires once at that instant.
+      # - duration ('3m', '10h', 'P12Y12M') → fires once at
+      #   +last_concrete + duration+.
+      # - recurring (cron, "every 3 seconds") → fires on each match
+      #   between its start and the next concrete bound.
       #
-      # With no args, returns the current run +RoleSpec+ (or nil).
-      def run_at(expression = NO_ARG, klass = NO_ARG, **payload)
-        return @run if expression.equal?(NO_ARG)
-        raise ArgumentError, 'run_at requires a command class' if klass.equal?(NO_ARG)
-
-        @expression = expression
-        parsed = Fugit.parse(expression) or raise ArgumentError, "invalid schedule expression: #{expression.inspect}"
-        # Cron / interval objects implement #next_time directly; date
-        # strings parse to EtOrbi::EoTime (a one-off instant) which
-        # we wrap.
-        @cron = parsed.respond_to?(:next_time) ? parsed : OneOff.new(parsed)
-
-        @run = RoleSpec.new(klass: klass, payload: payload)
-        self
-      end
-
-      # @return [RoleSpec, nil] the recurring command spec
-      def run = @run
-
-      def enter_at(time = NO_ARG, klass = nil, **payload)
-        return @enter_at if time.equal?(NO_ARG)
-
-        @enter_at = coerce_time(time)
-        @enter = klass ? RoleSpec.new(klass: klass, payload: payload) : nil
-        self
-      end
-
-      # exit_at accepts:
-      # - a +Time+, +DateTime+, or absolute ISO8601 string — evaluated as-is.
-      # - a callable (proc/lambda/method) — invoked at finalize with
-      #   the resolved +enter_at+.
-      # - an ISO8601 duration string ("P12Y12M") or Fugit duration
-      #   ("12y12M", "1h30m", "90s") — added to the resolved
-      #   +enter_at+ at finalize.
+      # The +klass+ is optional for specific and duration steps —
+      # omit it to declare a **bound-only marker** that anchors the
+      # timeline without dispatching anything (useful as a starting
+      # boundary for a following recurring or duration step, or as a
+      # closing boundary for a preceding recurring step). Recurring
+      # steps require +klass+ since a recurring with no command would
+      # fire nothing on every match.
       #
-      # Callable and duration forms both *require* +enter_at+ and
-      # raise a guidance-rich error at finalize when it's missing.
-      def exit_at(value = NO_ARG, klass = nil, **payload)
-        return @exit_at if value.equal?(NO_ARG)
-
-        resolver, kind = relative_exit_at(value)
-        if resolver
-          @exit_at_relative_resolver = resolver
-          @exit_at_relative_kind = kind
-        else
-          @exit_at = coerce_time(value)
+      # Block form is intentionally not supported here — the
+      # Scheduler stays class-agnostic. Use {Sidereal::Scheduling}'s
+      # +schedule+ macro to auto-generate per-step command classes
+      # from blocks.
+      def at(expression, klass = nil, **payload, &block)
+        if block
+          raise ArgumentError,
+                'block form is supported only via Sidereal::Scheduling DSL; ' \
+                'pass an explicit command class to Schedule#at'
         end
-        @exit = klass ? RoleSpec.new(klass: klass, payload: payload) : nil
+
+        @raw_steps << { expression: expression, klass: klass, payload: payload }
         self
       end
 
-      # Resolve relative +exit_at+ (callable or duration), validate
-      # the window, and freeze. Idempotent.
-      def finalize!
+      # Resolve all steps against +baseline+ and freeze. Idempotent.
+      # Validates: no time-travel for specific steps, no consecutive
+      # recurring steps, durations resolve to a strictly later
+      # concrete time.
+      def finalize!(baseline:)
         return self if frozen?
 
-        raise ArgumentError, 'schedule run_at is required' unless @run
+        raise ArgumentError, "schedule #{@name.inspect}: must declare at least one at(...)" if @raw_steps.empty?
 
-        if @exit_at_relative_resolver
-          unless @enter_at
-            kind = @exit_at_relative_kind
-            raise ArgumentError,
-                  "schedule #{@name.inspect}: exit_at was given a #{kind} but no enter_at is set. " \
-                  "#{kind.capitalize}s are resolved relative to enter_at; either declare enter_at, " \
-                  'or pass a static Time/String/DateTime to exit_at.'
-          end
+        resolved = []
+        last_concrete = baseline
+        pending_recurring_idx = nil
 
-          @exit_at = coerce_time(@exit_at_relative_resolver.call(@enter_at))
+        @raw_steps.each_with_index do |raw, i|
+          step, last_concrete, pending_recurring_idx =
+            resolve_step(raw, i, baseline, last_concrete, pending_recurring_idx, resolved)
+          resolved << step
         end
 
-        validate_window!
+        @steps = resolved.freeze
+        @baseline_used = baseline
         freeze
         self
       end
 
-      def active_at?(time)
-        return false if @enter_at && time < @enter_at
-        return false if @exit_at  && time > @exit_at
-
-        true
-      end
-
       private
 
-      # Detect whether +value+ is a relative exit_at form (callable or
-      # a Fugit-parseable duration string). Returns +[resolver_proc,
-      # kind]+ or nil. Each resolver, when given the resolved
-      # +enter_at+, returns a Time-like (Time, EoTime, DateTime).
-      def relative_exit_at(value)
-        if value.respond_to?(:call) && !value.is_a?(Time)
-          [value, 'callable']
-        elsif value.is_a?(String) && (duration = parse_duration(value))
-          [->(enter_at) { duration.add_to_time(enter_at) }, 'duration']
-        end
-      end
+      # @return [Array(Step, last_concrete, pending_recurring_idx)] the
+      #   resolved step plus updated walk state.
+      def resolve_step(raw, idx, baseline, last_concrete, pending_recurring_idx, resolved)
+        parsed = parse_expression(raw[:expression], idx)
 
-      # @return [Fugit::Duration, nil] the parsed duration, or nil if
-      #   the string isn't a duration expression.
-      def parse_duration(str)
-        parsed = Fugit.parse(str)
-        parsed.is_a?(Fugit::Duration) ? parsed : nil
-      end
+        case parsed
+        when Fugit::Duration
+          t = parsed.add_to_time(last_concrete).to_local_time
+          if t <= last_concrete
+            raise ArgumentError,
+                  "schedule #{@name.inspect}: step ##{idx} (#{raw[:expression].inspect}) resolves to " \
+                  "#{t.iso8601}, not after the previous concrete time #{last_concrete.iso8601}"
+          end
+          close_pending_recurring!(resolved, pending_recurring_idx, t)
+          step = Step::Specific.new(index: idx, expression: raw[:expression], at: t,
+                                    klass: raw[:klass], payload: raw[:payload])
+          [step, t, nil]
 
-      def coerce_time(v)
-        case v
-        when nil    then nil
-        when Time   then v
-        when String then Time.parse(v)
+        when EtOrbi::EoTime
+          t = parsed.to_local_time
+          # Time-travel guard: only validate when a previous user step
+          # actually advanced last_concrete past baseline. The very
+          # first user step is allowed to be in the past — it simply
+          # never fires.
+          if last_concrete > baseline && t <= last_concrete
+            raise ArgumentError,
+                  "schedule #{@name.inspect}: specific time at step ##{idx} (#{t.iso8601}) " \
+                  "must be after the previous concrete time (#{last_concrete.iso8601})"
+          end
+          close_pending_recurring!(resolved, pending_recurring_idx, t)
+          step = Step::Specific.new(index: idx, expression: raw[:expression], at: t,
+                                    klass: raw[:klass], payload: raw[:payload])
+          [step, t, nil]
+
         else
-          # EtOrbi::EoTime → to_local_time; DateTime → to_time.
-          return v.to_local_time if v.respond_to?(:to_local_time)
-          return v.to_time       if v.respond_to?(:to_time)
-
-          raise ArgumentError, "expected Time, DateTime, or ISO8601 String; got #{v.inspect}"
+          unless parsed.respond_to?(:next_time)
+            raise ArgumentError,
+                  "schedule #{@name.inspect}: expression at step ##{idx} (#{parsed.class}) " \
+                  'does not support next_time'
+          end
+          if raw[:klass].nil?
+            raise ArgumentError,
+                  "schedule #{@name.inspect}: recurring step ##{idx} (#{raw[:expression].inspect}) " \
+                  'requires a command class — bound-only markers are only meaningful for specific or duration steps'
+          end
+          if pending_recurring_idx
+            raise ArgumentError,
+                  "schedule #{@name.inspect}: step ##{idx} (#{raw[:expression].inspect}) is recurring " \
+                  "but the previous step (##{pending_recurring_idx}) is also recurring with no closing bound. " \
+                  'A concrete (specific or duration) step must separate two recurring steps.'
+          end
+          step = Step::Recurring.new(index: idx, expression: raw[:expression], cron: parsed,
+                                     from: last_concrete, to: nil,
+                                     klass: raw[:klass], payload: raw[:payload])
+          [step, last_concrete, idx]
         end
       end
 
-      def validate_window!
-        return unless @enter_at && @exit_at
+      # Coerce the user-supplied expression into something the
+      # resolution walk can branch on. Strings go through +Fugit.parse+;
+      # +Time+, +DateTime+, +EtOrbi::EoTime+ (and any +#to_time+
+      # responder) short-circuit to an EoTime so they hit the specific
+      # branch directly.
+      def parse_expression(expr, idx)
+        case expr
+        when EtOrbi::EoTime then expr
+        when Time           then EtOrbi::EoTime.make(expr)
+        when String
+          Fugit.parse(expr) or
+            raise ArgumentError, "schedule #{@name.inspect}: invalid expression at step ##{idx}: #{expr.inspect}"
+        else
+          if expr.respond_to?(:to_time)
+            EtOrbi::EoTime.make(expr.to_time)
+          else
+            raise ArgumentError,
+                  "schedule #{@name.inspect}: step ##{idx} expression must be a String, Time, " \
+                  "DateTime, or EtOrbi::EoTime; got #{expr.inspect}"
+          end
+        end
+      end
 
-        next_fire = @cron.next_time(@enter_at)&.to_local_time
-        return if next_fire && next_fire <= @exit_at
+      # Close the pending recurring step (if any) by replacing it in
+      # +resolved+ with a copy whose +to+ is set to +t+.
+      def close_pending_recurring!(resolved, pending_recurring_idx, t)
+        return if pending_recurring_idx.nil?
 
-        raise ArgumentError,
-              "schedule run #{@expression.inspect} ('#{@name}') never fires inside the window [#{@enter_at.iso8601}, #{@exit_at.iso8601}]"
+        prev = resolved[pending_recurring_idx]
+        resolved[pending_recurring_idx] = Step::Recurring.new(
+          index: prev.index, expression: prev.expression, cron: prev.cron,
+          from: prev.from, to: t, klass: prev.klass, payload: prev.payload
+        )
       end
     end
 
-    def initialize(tick_interval: DEFAULT_TICK_INTERVAL, clock: -> { Time.now }, store: nil, elector: nil)
+    attr_reader :baseline
+
+    def initialize(tick_interval: DEFAULT_TICK_INTERVAL, clock: -> { Time.now }, baseline: nil, store: nil, elector: nil)
       @tick_interval = tick_interval
       @clock = clock
+      @baseline = baseline || @clock.call
       @store = store
-      @elector = elector            # nil = resolve from Sidereal.elector at start time
-      @schedules = []               # registration order
+      @elector = elector
+      @schedules = []
       @last_tick_at = nil
       @tick_fiber = nil
     end
 
     # Register a schedule. Accepts either a String name (constructs a
-    # fresh +Schedule+) or a pre-built +Schedule+ instance. The name
-    # is mandatory; empty/nil rejected at the +Schedule+ constructor.
-    # The block (when given) builds the schedule via the +Schedule+
-    # builder methods (+run_at+, +enter_at+, +exit_at+).
-    #
-    # @return [self]
+    # fresh +Schedule+) or a pre-built +Schedule+ instance. The block
+    # (when given) builds the schedule via +Schedule#at+.
     def schedule(name_or_instance)
       sch = case name_or_instance
             when Schedule then name_or_instance
@@ -241,12 +243,11 @@ module Sidereal
             else raise ArgumentError, "expected Schedule or String name; got #{name_or_instance.inspect}"
             end
       yield(sch) if block_given?
-      sch.finalize!
+      sch.finalize!(baseline: @baseline)
       @schedules << sch
       self
     end
 
-    # @return [Array<Schedule>] registered schedules in registration order
     def schedules = @schedules.dup
 
     def start(task)
@@ -257,39 +258,17 @@ module Sidereal
     end
 
     # @param now [Time] explicit firing instant; defaults to +@clock.call+.
-    #   Useful in tests so you don't have to mock the clock — just pass
-    #   the time you want the tick to evaluate as.
     def tick(now = @clock.call)
       baseline = @last_tick_at || now
       store = @store || Sidereal.store
 
-      @schedules.each_with_index do |sch, id|
-        metadata = build_metadata(sch, id)
-        enter_or_exit_fired = false
+      @schedules.each_with_index do |sch, schedule_id|
+        sch.steps.each do |step|
+          next unless step.fires_in?(baseline, now)
 
-        if sch.enter && bound_in_window?(sch.enter_at, baseline, now)
-          dispatch(store, sch.enter, metadata)
-          enter_or_exit_fired = true
+          metadata = build_metadata(sch, schedule_id, step)
+          dispatch(store, step, metadata)
         end
-
-        if sch.exit && bound_in_window?(sch.exit_at, baseline, now)
-          dispatch(store, sch.exit, metadata)
-          enter_or_exit_fired = true
-        end
-
-        # Skip run on the same tick that fired enter/exit so the
-        # asynchronous worker pool processes them in the desired
-        # order: enter strictly before any run, exit strictly after.
-        next if enter_or_exit_fired
-        next unless sch.active_at?(now)
-
-        # Fugit::At returns nil from +next_time+ once the at-instant has
-        # passed — guards against NPE and naturally prevents one-offs
-        # from refiring.
-        next_at = sch.cron.next_time(baseline)&.to_local_time
-        next if next_at.nil? || next_at > now
-
-        dispatch(store, sch.run, metadata)
       end
 
       @last_tick_at = now
@@ -297,26 +276,23 @@ module Sidereal
 
     private
 
-    def bound_in_window?(instant, baseline, now)
-      instant && instant > baseline && instant <= now
+    def build_metadata(sch, schedule_id, step)
+      {
+        producer: producer_label(schedule_id, sch, step),
+        schedule_name: sch.name
+      }
     end
 
-    # Compute the per-firing metadata. Apps that want a different
-    # shape can override this on a Scheduler subclass.
-    def build_metadata(sch, id)
-      { producer: producer_label(id, sch), schedule_name: sch.name }
+    def producer_label(schedule_id, sch, step)
+      "Schedule ##{schedule_id} '#{sch.name}' step ##{step.index} (#{step.expression})"
     end
 
-    def producer_label(id, sch)
-      "Schedule ##{id} '#{sch.name}' (#{sch.expression})"
-    end
-
-    def dispatch(store, role_spec, metadata)
-      msg = role_spec.klass.parse(payload: role_spec.payload, metadata: metadata)
+    def dispatch(store, step, metadata)
+      msg = step.klass.parse(payload: step.payload, metadata: metadata)
       store.append(msg)
     rescue StandardError => ex
       Console.error(self, 'failed to dispatch scheduled command',
-                    klass: role_spec.klass.name, exception: ex)
+                    klass: step.klass.name, exception: ex)
     end
 
     def spawn_tick_fiber(task)

--- a/lib/sidereal/scheduler.rb
+++ b/lib/sidereal/scheduler.rb
@@ -36,6 +36,8 @@ module Sidereal
     # in registration order, used by +TriggerSchedule.payload.schedule_id+
     # to look the schedule back up at handle time.
     Schedule = Data.define(:id, :cron_expr, :cron, :block) do
+      def name = "Schedule ##{id} (#{cron_expr})"
+
       # Execute the schedule's block on +context+ via instance_exec, so
       # the block sees +context+'s methods (typically a Commander
       # instance, exposing +dispatch+, +broadcast+, +pubsub+, etc.).
@@ -105,7 +107,7 @@ module Sidereal
           store.append(
             Sidereal::System::TriggerSchedule.new(
               payload: { schedule_id: sch.id },
-              metadata: { producer: sch.cron_expr }
+              metadata: { producer: sch.name }
             )
           )
         rescue StandardError => ex

--- a/lib/sidereal/scheduler.rb
+++ b/lib/sidereal/scheduler.rb
@@ -70,12 +70,14 @@ module Sidereal
       end
     end
 
-    def initialize(tick_interval: DEFAULT_TICK_INTERVAL, clock: -> { Time.now }, store: nil)
+    def initialize(tick_interval: DEFAULT_TICK_INTERVAL, clock: -> { Time.now }, store: nil, elector: nil)
       @tick_interval = tick_interval
       @clock = clock
       @store = store
+      @elector = elector            # nil = resolve from Sidereal.elector at start time
       @schedules = []
       @last_tick_at = nil
+      @tick_fiber = nil
     end
 
     # Register a cron-scheduled block. Idempotency on duplicate
@@ -93,15 +95,15 @@ module Sidereal
     # @return [Array<Schedule>] copy of the registered schedules
     def schedules = @schedules.dup
 
-    # Spawn the tick fiber as a child of +task+. Mirrors
-    # {Sidereal::Dispatcher.start} — returns self.
+    # Wire the tick fiber's lifecycle to the elector: spawn when this
+    # process is leader, stop when demoted. With the default
+    # {Elector::AlwaysLeader}, +on_promote+ fires immediately on
+    # registration and the fiber starts straight away — same behaviour
+    # as before electors existed.
     def start(task)
-      task.async do
-        loop do
-          tick
-          sleep @tick_interval
-        end
-      end
+      elector = @elector || Sidereal.elector
+      elector.on_promote { spawn_tick_fiber(task) }
+      elector.on_demote { stop_tick_fiber }
       self
     end
 
@@ -126,6 +128,27 @@ module Sidereal
       run.call
     rescue StandardError => ex
       Console.error(self, 'scheduled block raised', cron: run.cron_expr, exception: ex)
+    end
+
+    def spawn_tick_fiber(task)
+      return if @tick_fiber
+
+      @tick_fiber = task.async do
+        loop do
+          tick
+          sleep @tick_interval
+        end
+      end
+    end
+
+    def stop_tick_fiber
+      f = @tick_fiber
+      @tick_fiber = nil
+      f&.stop
+      # Reset cursor so the next promotion starts a fresh window — without
+      # this, a long demotion would cause a one-shot fire on re-promotion
+      # for any cron whose boundary fell during the demotion.
+      @last_tick_at = nil
     end
   end
 end

--- a/lib/sidereal/scheduling.rb
+++ b/lib/sidereal/scheduling.rb
@@ -1,36 +1,201 @@
 # frozen_string_literal: true
 
 module Sidereal
-  # Register a cron-scheduled block. The block runs on every tick of
-  # the cron expression, dispatched as a +TriggerSchedule+ command and
-  # handled by this commander's worker pool. Inside the block,
-  # +dispatch(MessageClass, payload)+ enqueues commands onto
-  # {Sidereal.store} stamped with a +producer+ metadata string
-  # ("Schedule #<id> '<name>' (<cron_expr>)") that propagates via
-  # +Message#correlate+.
+  # Mixin for hosts (typically {Sidereal::Commander}) that exposes a
+  # +schedule+ class macro. The macro generates per-schedule command
+  # classes under +<HostCommander>::Schedules+, defines regular command
+  # handlers for them, and registers a Schedule with
+  # {Sidereal.scheduler}.
   #
-  # Two call shapes — see {Sidereal::Scheduler#schedule}:
-  # @example Auto-named
-  #   schedule '5 0 * * *' do |cmd|
-  #     dispatch Cleanup, foo: 'bar'
-  #   end
-  # @example Named
-  #   schedule 'Recurring cleanup', '5 0 * * *' do |cmd|
-  #     dispatch Cleanup, foo: 'bar'
-  #   end
-  #
-  # @return [self]
+  # The Scheduler itself is dumb and message-class-agnostic: it stores
+  # +{type:, payload:, metadata:}+ hashes and appends materialised
+  # {Sidereal::Message} instances to the store at the right time.
   module Scheduling
-    def schedule(...)
-      Sidereal.scheduler.schedule(...)
+    ROLES = [:run, :enter, :exit].freeze
 
-      command Sidereal::System::TriggerSchedule do |cmd|
-        schedule = Sidereal.scheduler.find(cmd.payload.schedule_id)
-        return unless schedule
+    def self.included(host)
+      super
 
-        schedule.run_in(self, cmd)
+      host.const_set(:Schedules, Module.new)
+      host.extend ClassMethods
+      # Each subclass gets its own +Schedules+ namespace so different
+      # hosts don't collide on identically-named schedules.
+      host.singleton_class.prepend(SubclassHook)
+    end
+
+    module SubclassHook
+      def inherited(subclass)
+        super
+        subclass.const_set(:Schedules, Module.new) unless subclass.const_defined?(:Schedules, false)
       end
-      self
+    end
+
+    # Inner DSL for {ClassMethods#schedule}. The block passed to
+    # +schedule+ is +instance_eval+'d on a builder so the user can
+    # declare +enter_at+ / +run_at+ / +exit_at+.
+    #
+    # Each role accepts one of three shapes:
+    # 1. A block — the macro generates a per-schedule command class
+    #    under +<HostCommander>::Schedules+ and wires the block as
+    #    that class's handler.
+    # 2. An explicit command class + payload kwargs — the macro
+    #    passes them straight through to the lower-level
+    #    {Sidereal::Scheduler::Schedule}; no class is generated and
+    #    no handler is defined (caller wires +command+ themselves).
+    # 3. (enter_at / exit_at only) Just a time argument — bound only,
+    #    no command at all. The schedule's active window still gates
+    #    +run+, but no Enter/Exit signal is dispatched.
+    #
+    # +run_at+ requires either a block or a class; +enter_at+ and
+    # +exit_at+ may legitimately have neither.
+    class ScheduleBuilder
+      Entry = Data.define(:arg, :block, :klass, :payload)
+
+      attr_reader :entries
+
+      def initialize
+        @entries = {}
+      end
+
+      def enter_at(time, klass = nil, **payload, &block)
+        validate_either!(:enter_at, klass, block)
+        @entries[:enter] = Entry.new(arg: time, block: block, klass: klass, payload: payload)
+      end
+
+      def run_at(expression, klass = nil, **payload, &block)
+        validate_either!(:run_at, klass, block)
+        raise ArgumentError, 'run_at requires a block or a command class' unless klass || block
+
+        @entries[:run] = Entry.new(arg: expression, block: block, klass: klass, payload: payload)
+      end
+
+      def exit_at(time_or_callable_or_duration, klass = nil, **payload, &block)
+        validate_either!(:exit_at, klass, block)
+        @entries[:exit] = Entry.new(
+          arg: time_or_callable_or_duration, block: block, klass: klass, payload: payload
+        )
+      end
+
+      private
+
+      def validate_either!(method, klass, block)
+        return unless klass && block
+
+        raise ArgumentError, "#{method}: pass either a block or a command class, not both"
+      end
+    end
+
+    module ClassMethods
+      # Register a schedule. The block is +instance_eval+'d on a
+      # {ScheduleBuilder} that exposes +enter_at+, +run_at+, and
+      # +exit_at+. +run_at+ is required.
+      #
+      # @example
+      #   schedule 'Clock tick' do
+      #     enter_at '2026-05-03T10:20:00' do |cmd|
+      #       # handler for the auto-generated Enter command
+      #     end
+      #     run_at 'every 3 seconds' do |cmd|
+      #       # handler for the Run command (required)
+      #     end
+      #     exit_at ->(enter_time) { enter_time + 3600 } do |cmd|
+      #       # handler for the Exit command
+      #     end
+      #   end
+      #
+      # Per-schedule command classes are generated under
+      # +<HostCommander>::Schedules+ with names like +SchedClockTick0Run+,
+      # +SchedClockTick0Enter+, +SchedClockTick0Exit+ (where +0+ is the
+      # schedule's monotonic registration index).
+      def schedule(name, &block)
+        raise ArgumentError, 'schedule requires a block' unless block
+        raise ArgumentError, 'schedule name is required' if name.nil? || name.to_s.empty?
+
+        id = (@__schedule_counter ||= -1) + 1
+        @__schedule_counter = id
+
+        entries = collect_entries(name, &block)
+        host = self
+
+        Sidereal.scheduler.schedule(name) do |sc|
+          host.send(:apply_role_to_schedule, sc, name, id, :enter, entries[:enter])
+          host.send(:apply_role_to_schedule, sc, name, id, :run,   entries[:run])
+          host.send(:apply_role_to_schedule, sc, name, id, :exit,  entries[:exit])
+        end
+        self
+      end
+
+      private
+
+      # Translate a captured +Entry+ into a call on the lower-level
+      # {Sidereal::Scheduler::Schedule}. Three shapes per role:
+      # block (generate class + handler), explicit class (pass
+      # through), or bound-only (enter_at / exit_at without command).
+      def apply_role_to_schedule(sc, name, id, role, entry)
+        return if entry.nil?
+
+        if entry.block
+          klass = define_schedule_command(name, id, role)
+          command(klass, &entry.block)
+          send_role_to_sc(sc, role, entry.arg, klass)
+        elsif entry.klass
+          send_role_to_sc(sc, role, entry.arg, entry.klass, **entry.payload)
+        else
+          # No command — bound-only. Only meaningful for enter_at/exit_at;
+          # collect_entries already rejects run_at without block-or-class.
+          send_role_to_sc(sc, role, entry.arg)
+        end
+      end
+
+      def send_role_to_sc(sc, role, *args, **kwargs)
+        method = role == :run ? :run_at : :"#{role}_at"
+        sc.public_send(method, *args, **kwargs)
+      end
+
+      # Drive the user's block on a {ScheduleBuilder} and return the
+      # captured entries. The block must take no arguments and must
+      # call +run_at+ at least once.
+      def collect_entries(name, &block)
+        unless block.arity.zero?
+          raise ArgumentError, "schedule #{name.inspect}: block must take no arguments; use the inner DSL (run_at, enter_at, exit_at)"
+        end
+
+        builder = ScheduleBuilder.new
+        builder.instance_eval(&block)
+        unless builder.entries[:run]
+          raise ArgumentError, "schedule #{name.inspect}: block must declare run_at"
+        end
+
+        builder.entries
+      end
+
+      # Class names are prefixed with +Sched+ so the generated constant
+      # is always a valid Ruby identifier even when the schedule name
+      # begins with a digit (e.g. +'5 minute'+ → +Sched5Minute0Run+).
+      SCHEDULE_CLASS_PREFIX = 'Sched'
+
+      def define_schedule_command(name, id, role)
+        host_namespace = const_get(:Schedules)
+        class_name = "#{SCHEDULE_CLASS_PREFIX}#{Sidereal::Utils.camel_case(name)}#{id}#{Sidereal::Utils.camel_case(role.to_s)}"
+        return host_namespace.const_get(class_name, false) if host_namespace.const_defined?(class_name, false)
+
+        type_str = "#{type_namespace}.schedules.#{Sidereal::Utils.snake_case(name)}_#{id}_#{role}"
+        # Empty payload — the Scheduler stamps schedule context
+        # (producer, schedule_name) into metadata at firing time.
+        klass = Sidereal::Message.define(type_str)
+        host_namespace.const_set(class_name, klass)
+        klass
+      end
+
+      # Derive the type-string namespace from the host class name.
+      # Strips a trailing +::Commander+ so an App-defined commander
+      # named +ChatApp::Commander+ produces +chat_app+ rather than
+      # the noisier +chat_app_commander+.
+      def type_namespace
+        return 'anonymous' if self.name.nil?
+
+        Sidereal::Utils.snake_case(self.name.sub(/::Commander\z/, ''))
+      end
     end
   end
 end

--- a/lib/sidereal/scheduling.rb
+++ b/lib/sidereal/scheduling.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Sidereal
+  # Register a cron-scheduled block. The block runs on every tick of
+  # the cron expression, on a fiber spawned by {Sidereal.scheduler}.
+  # Inside the block, +dispatch(MessageClass, payload)+ enqueues a
+  # command onto {Sidereal.store} stamped with
+  # +metadata: { producer: '<cron expr>' }+.
+  #
+  # @example
+  #   schedule '5 0 * * *' do
+  #     dispatch Cleanup, foo: 'bar'
+  #   end
+  #
+  # @param cron_expr [String] cron expression (5 or 6 fields)
+  # @return [self]
+  module Scheduling
+    def schedule(cron_expr, &block)
+      Sidereal.scheduler.schedule(cron_expr, &block)
+
+      command Sidereal::System::TriggerSchedule do |cmd|
+        schedule = Sidereal.scheduler.find(cmd.payload.schedule_id)
+        return unless schedule
+
+        schedule.run_in(self, cmd)
+      end
+      self
+    end
+  end
+end

--- a/lib/sidereal/scheduling.rb
+++ b/lib/sidereal/scheduling.rb
@@ -2,21 +2,27 @@
 
 module Sidereal
   # Register a cron-scheduled block. The block runs on every tick of
-  # the cron expression, on a fiber spawned by {Sidereal.scheduler}.
-  # Inside the block, +dispatch(MessageClass, payload)+ enqueues a
-  # command onto {Sidereal.store} stamped with
-  # +metadata: { producer: '<cron expr>' }+.
+  # the cron expression, dispatched as a +TriggerSchedule+ command and
+  # handled by this commander's worker pool. Inside the block,
+  # +dispatch(MessageClass, payload)+ enqueues commands onto
+  # {Sidereal.store} stamped with a +producer+ metadata string
+  # ("Schedule #<id> '<name>' (<cron_expr>)") that propagates via
+  # +Message#correlate+.
   #
-  # @example
-  #   schedule '5 0 * * *' do
+  # Two call shapes — see {Sidereal::Scheduler#schedule}:
+  # @example Auto-named
+  #   schedule '5 0 * * *' do |cmd|
+  #     dispatch Cleanup, foo: 'bar'
+  #   end
+  # @example Named
+  #   schedule 'Recurring cleanup', '5 0 * * *' do |cmd|
   #     dispatch Cleanup, foo: 'bar'
   #   end
   #
-  # @param cron_expr [String] cron expression (5 or 6 fields)
   # @return [self]
   module Scheduling
-    def schedule(cron_expr, &block)
-      Sidereal.scheduler.schedule(cron_expr, &block)
+    def schedule(...)
+      Sidereal.scheduler.schedule(...)
 
       command Sidereal::System::TriggerSchedule do |cmd|
         schedule = Sidereal.scheduler.find(cmd.payload.schedule_id)

--- a/lib/sidereal/scheduling.rb
+++ b/lib/sidereal/scheduling.rb
@@ -2,17 +2,11 @@
 
 module Sidereal
   # Mixin for hosts (typically {Sidereal::Commander}) that exposes a
-  # +schedule+ class macro. The macro generates per-schedule command
-  # classes under +<HostCommander>::Schedules+, defines regular command
-  # handlers for them, and registers a Schedule with
+  # +schedule+ class macro. The macro generates per-step command
+  # classes under +<HostCommander>::Schedules+, defines regular
+  # command handlers for them, and registers a +Schedule+ with
   # {Sidereal.scheduler}.
-  #
-  # The Scheduler itself is dumb and message-class-agnostic: it stores
-  # +{type:, payload:, metadata:}+ hashes and appends materialised
-  # {Sidereal::Message} instances to the store at the right time.
   module Scheduling
-    ROLES = [:run, :enter, :exit].freeze
-
     def self.included(host)
       super
 
@@ -32,154 +26,109 @@ module Sidereal
 
     # Inner DSL for {ClassMethods#schedule}. The block passed to
     # +schedule+ is +instance_eval+'d on a builder so the user can
-    # declare +enter_at+ / +run_at+ / +exit_at+.
-    #
-    # Each role accepts one of three shapes:
-    # 1. A block — the macro generates a per-schedule command class
-    #    under +<HostCommander>::Schedules+ and wires the block as
-    #    that class's handler.
-    # 2. An explicit command class + payload kwargs — the macro
-    #    passes them straight through to the lower-level
-    #    {Sidereal::Scheduler::Schedule}; no class is generated and
-    #    no handler is defined (caller wires +command+ themselves).
-    # 3. (enter_at / exit_at only) Just a time argument — bound only,
-    #    no command at all. The schedule's active window still gates
-    #    +run+, but no Enter/Exit signal is dispatched.
-    #
-    # +run_at+ requires either a block or a class; +enter_at+ and
-    # +exit_at+ may legitimately have neither.
+    # call +at+ once per step. Each +at+ accepts either a block (the
+    # macro generates a per-step command class with the block as
+    # handler) or an explicit class + payload kwargs (passed straight
+    # through to the lower-level Scheduler).
     class ScheduleBuilder
-      Entry = Data.define(:arg, :block, :klass, :payload)
+      Entry = Data.define(:expression, :klass, :payload, :block)
 
       attr_reader :entries
 
       def initialize
-        @entries = {}
+        @entries = []
       end
 
-      def enter_at(time, klass = nil, **payload, &block)
-        validate_either!(:enter_at, klass, block)
-        @entries[:enter] = Entry.new(arg: time, block: block, klass: klass, payload: payload)
-      end
+      # Three call shapes:
+      # - +at(expr) { |cmd| ... }+ — block; macro generates a per-step
+      #   command class and wires the block as its handler.
+      # - +at(expr, klass, **payload)+ — explicit class; pass-through.
+      # - +at(expr)+ — bound-only marker; anchors the timeline without
+      #   dispatching anything (only valid for specific/duration
+      #   expressions; the lower-level Scheduler raises on a
+      #   recurring marker at finalize).
+      def at(expression, klass = nil, **payload, &block)
+        if klass && block
+          raise ArgumentError, 'at: pass either a block or a command class, not both'
+        end
 
-      def run_at(expression, klass = nil, **payload, &block)
-        validate_either!(:run_at, klass, block)
-        raise ArgumentError, 'run_at requires a block or a command class' unless klass || block
-
-        @entries[:run] = Entry.new(arg: expression, block: block, klass: klass, payload: payload)
-      end
-
-      def exit_at(time_or_callable_or_duration, klass = nil, **payload, &block)
-        validate_either!(:exit_at, klass, block)
-        @entries[:exit] = Entry.new(
-          arg: time_or_callable_or_duration, block: block, klass: klass, payload: payload
-        )
-      end
-
-      private
-
-      def validate_either!(method, klass, block)
-        return unless klass && block
-
-        raise ArgumentError, "#{method}: pass either a block or a command class, not both"
+        @entries << Entry.new(expression: expression, klass: klass, payload: payload, block: block)
       end
     end
 
     module ClassMethods
+      # Class names are prefixed with +Sched+ so the generated
+      # constant is always a valid Ruby identifier even when the
+      # schedule name begins with a digit.
+      SCHEDULE_CLASS_PREFIX = 'Sched'
+
       # Register a schedule. The block is +instance_eval+'d on a
-      # {ScheduleBuilder} that exposes +enter_at+, +run_at+, and
-      # +exit_at+. +run_at+ is required.
+      # {ScheduleBuilder}; declare one or more +at+ steps inside.
       #
-      # @example
-      #   schedule 'Clock tick' do
-      #     enter_at '2026-05-03T10:20:00' do |cmd|
-      #       # handler for the auto-generated Enter command
+      # @example Specific datetime + recurring + duration
+      #   schedule 'Tick campaign' do
+      #     at '2026-05-06T15:00:00' do |cmd|
+      #       # fires once at the boundary
       #     end
-      #     run_at 'every 3 seconds' do |cmd|
-      #       # handler for the Run command (required)
+      #     at 'every 3 seconds' do |cmd|
+      #       # fires recurring until the next concrete bound
       #     end
-      #     exit_at ->(enter_time) { enter_time + 3600 } do |cmd|
-      #       # handler for the Exit command
+      #     at '30s' do |cmd|
+      #       # fires at start + 30s, closes the recurring
       #     end
       #   end
       #
-      # Per-schedule command classes are generated under
-      # +<HostCommander>::Schedules+ with names like +SchedClockTick0Run+,
-      # +SchedClockTick0Enter+, +SchedClockTick0Exit+ (where +0+ is the
-      # schedule's monotonic registration index).
+      # @example Explicit command classes
+      #   schedule 'Flash sale' do
+      #     at '2026-05-10T10:00:00', StartCampaign
+      #     at '5/* * * *', LookupResults
+      #     at '10h', EndCampaign
+      #   end
       def schedule(name, &block)
         raise ArgumentError, 'schedule requires a block' unless block
         raise ArgumentError, 'schedule name is required' if name.nil? || name.to_s.empty?
 
+        unless block.arity.zero?
+          raise ArgumentError,
+                "schedule #{name.inspect}: block must take no arguments; use the inner DSL (at(...))"
+        end
+
         id = (@__schedule_counter ||= -1) + 1
         @__schedule_counter = id
 
-        entries = collect_entries(name, &block)
+        builder = ScheduleBuilder.new
+        builder.instance_eval(&block)
+        if builder.entries.empty?
+          raise ArgumentError, "schedule #{name.inspect}: block must declare at least one at(...)"
+        end
+
         host = self
 
         Sidereal.scheduler.schedule(name) do |sc|
-          host.send(:apply_role_to_schedule, sc, name, id, :enter, entries[:enter])
-          host.send(:apply_role_to_schedule, sc, name, id, :run,   entries[:run])
-          host.send(:apply_role_to_schedule, sc, name, id, :exit,  entries[:exit])
+          builder.entries.each_with_index do |entry, step_idx|
+            if entry.block
+              klass = host.send(:__define_step_command, name, id, step_idx)
+              host.command(klass, &entry.block)
+              sc.at entry.expression, klass
+            elsif entry.klass
+              sc.at entry.expression, entry.klass, **entry.payload
+            else
+              # Bound-only marker — no class, no block.
+              sc.at entry.expression
+            end
+          end
         end
         self
       end
 
       private
 
-      # Translate a captured +Entry+ into a call on the lower-level
-      # {Sidereal::Scheduler::Schedule}. Three shapes per role:
-      # block (generate class + handler), explicit class (pass
-      # through), or bound-only (enter_at / exit_at without command).
-      def apply_role_to_schedule(sc, name, id, role, entry)
-        return if entry.nil?
-
-        if entry.block
-          klass = define_schedule_command(name, id, role)
-          command(klass, &entry.block)
-          send_role_to_sc(sc, role, entry.arg, klass)
-        elsif entry.klass
-          send_role_to_sc(sc, role, entry.arg, entry.klass, **entry.payload)
-        else
-          # No command — bound-only. Only meaningful for enter_at/exit_at;
-          # collect_entries already rejects run_at without block-or-class.
-          send_role_to_sc(sc, role, entry.arg)
-        end
-      end
-
-      def send_role_to_sc(sc, role, *args, **kwargs)
-        method = role == :run ? :run_at : :"#{role}_at"
-        sc.public_send(method, *args, **kwargs)
-      end
-
-      # Drive the user's block on a {ScheduleBuilder} and return the
-      # captured entries. The block must take no arguments and must
-      # call +run_at+ at least once.
-      def collect_entries(name, &block)
-        unless block.arity.zero?
-          raise ArgumentError, "schedule #{name.inspect}: block must take no arguments; use the inner DSL (run_at, enter_at, exit_at)"
-        end
-
-        builder = ScheduleBuilder.new
-        builder.instance_eval(&block)
-        unless builder.entries[:run]
-          raise ArgumentError, "schedule #{name.inspect}: block must declare run_at"
-        end
-
-        builder.entries
-      end
-
-      # Class names are prefixed with +Sched+ so the generated constant
-      # is always a valid Ruby identifier even when the schedule name
-      # begins with a digit (e.g. +'5 minute'+ → +Sched5Minute0Run+).
-      SCHEDULE_CLASS_PREFIX = 'Sched'
-
-      def define_schedule_command(name, id, role)
+      def __define_step_command(name, id, step_idx)
         host_namespace = const_get(:Schedules)
-        class_name = "#{SCHEDULE_CLASS_PREFIX}#{Sidereal::Utils.camel_case(name)}#{id}#{Sidereal::Utils.camel_case(role.to_s)}"
+        class_name = "#{SCHEDULE_CLASS_PREFIX}#{Sidereal::Utils.camel_case(name)}#{id}Step#{step_idx}"
         return host_namespace.const_get(class_name, false) if host_namespace.const_defined?(class_name, false)
 
-        type_str = "#{type_namespace}.schedules.#{Sidereal::Utils.snake_case(name)}_#{id}_#{role}"
+        type_str = "#{__type_namespace}.schedules.#{Sidereal::Utils.snake_case(name)}_#{id}_step_#{step_idx}"
         # Empty payload — the Scheduler stamps schedule context
         # (producer, schedule_name) into metadata at firing time.
         klass = Sidereal::Message.define(type_str)
@@ -190,8 +139,8 @@ module Sidereal
       # Derive the type-string namespace from the host class name.
       # Strips a trailing +::Commander+ so an App-defined commander
       # named +ChatApp::Commander+ produces +chat_app+ rather than
-      # the noisier +chat_app_commander+.
-      def type_namespace
+      # +chat_app_commander+.
+      def __type_namespace
         return 'anonymous' if self.name.nil?
 
         Sidereal::Utils.snake_case(self.name.sub(/::Commander\z/, ''))

--- a/lib/sidereal/scheduling.rb
+++ b/lib/sidereal/scheduling.rb
@@ -62,10 +62,9 @@ module Sidereal
       # schedule name begins with a digit.
       SCHEDULE_CLASS_PREFIX = 'Sched'
 
-      # Register a schedule. The block is +instance_eval+'d on a
-      # {ScheduleBuilder}; declare one or more +at+ steps inside.
+      # Register a schedule. Two call shapes:
       #
-      # @example Specific datetime + recurring + duration
+      # @example Multi-step (inner DSL) — block arity 0
       #   schedule 'Tick campaign' do
       #     at '2026-05-06T15:00:00' do |cmd|
       #       # fires once at the boundary
@@ -78,26 +77,46 @@ module Sidereal
       #     end
       #   end
       #
-      # @example Explicit command classes
+      # @example Single-step shorthand — block arity 1, expression as 2nd positional
+      #   schedule 'Cleanup', '*/5 * * * *' do |cmd|
+      #     # equivalent to:
+      #     #   schedule 'Cleanup' do
+      #     #     at '*/5 * * * *' do |cmd| ... end
+      #     #   end
+      #   end
+      #
+      # @example Explicit command classes (multi-step form)
       #   schedule 'Flash sale' do
       #     at '2026-05-10T10:00:00', StartCampaign
-      #     at '5/* * * *', LookupResults
-      #     at '10h', EndCampaign
+      #     at '*/5 * * * *',         LookupResults
+      #     at '10h',                 EndCampaign
       #   end
-      def schedule(name, &block)
+      def schedule(name, expression = nil, &block)
         raise ArgumentError, 'schedule requires a block' unless block
         raise ArgumentError, 'schedule name is required' if name.nil? || name.to_s.empty?
 
-        unless block.arity.zero?
-          raise ArgumentError,
-                "schedule #{name.inspect}: block must take no arguments; use the inner DSL (at(...))"
-        end
+        builder_block = if expression
+                          unless block.arity == 1
+                            raise ArgumentError,
+                                  "schedule #{name.inspect}: shorthand 'schedule(name, expression)' " \
+                                  'requires a block of arity 1 (the cmd argument)'
+                          end
+
+                          handler = block
+                          proc { at(expression, &handler) }
+                        else
+                          unless block.arity.zero?
+                            raise ArgumentError,
+                                  "schedule #{name.inspect}: block must take no arguments; use the inner DSL (at(...))"
+                          end
+                          block
+                        end
 
         id = (@__schedule_counter ||= -1) + 1
         @__schedule_counter = id
 
         builder = ScheduleBuilder.new
-        builder.instance_eval(&block)
+        builder.instance_eval(&builder_block)
         if builder.entries.empty?
           raise ArgumentError, "schedule #{name.inspect}: block must declare at least one at(...)"
         end

--- a/lib/sidereal/system.rb
+++ b/lib/sidereal/system.rb
@@ -49,5 +49,9 @@ module Sidereal
       attribute :error_message, Sidereal::Types::String
       attribute :backtrace, Sidereal::Types::Array.default([].freeze)
     end
+
+    TriggerSchedule = Notification.define('sidereal.system.trigger_schedule') do
+      attribute :schedule_id, Sidereal::Types::Integer
+    end
   end
 end

--- a/lib/sidereal/system.rb
+++ b/lib/sidereal/system.rb
@@ -52,6 +52,7 @@ module Sidereal
 
     TriggerSchedule = Notification.define('sidereal.system.trigger_schedule') do
       attribute :schedule_id, Sidereal::Types::Integer
+      attribute :schedule_name, Sidereal::Types::String.present
     end
   end
 end

--- a/lib/sidereal/system.rb
+++ b/lib/sidereal/system.rb
@@ -49,10 +49,5 @@ module Sidereal
       attribute :error_message, Sidereal::Types::String
       attribute :backtrace, Sidereal::Types::Array.default([].freeze)
     end
-
-    TriggerSchedule = Notification.define('sidereal.system.trigger_schedule') do
-      attribute :schedule_id, Sidereal::Types::Integer
-      attribute :schedule_name, Sidereal::Types::String.present
-    end
   end
 end

--- a/lib/sidereal/utils.rb
+++ b/lib/sidereal/utils.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Sidereal
+  # Generic string-shaping helpers reused across the framework.
+  # These are explicit module functions — call as
+  # +Sidereal::Utils.camel_case("...")+ rather than mixing in.
+  module Utils
+    module_function
+
+    # +"clock tick"+ → +"ClockTick"+. Splits on non-alphanumerics and
+    # capitalises each part. Leading digits are preserved as-is — so
+    # +"5 minute"+ → +"5Minute"+ (callers needing a valid Ruby
+    # constant should prefix the result themselves).
+    def camel_case(str)
+      str.to_s.split(/[^a-zA-Z0-9]+/).map { |part| part[0]&.upcase.to_s + part[1..].to_s }.join
+    end
+
+    # +"ChatApp::Commander"+ → +"chat_app_commander"+. Splits double-
+    # colons, inserts underscores at camelCase / acronym boundaries,
+    # downcases, then collapses runs of non-alphanumerics into single
+    # underscores and trims leading/trailing underscores.
+    def snake_case(str)
+      str.to_s
+         .gsub('::', '_')
+         .gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
+         .gsub(/([a-z\d])([A-Z])/, '\1_\2')
+         .downcase
+         .gsub(/[^a-z0-9]+/, '_')
+         .gsub(/^_+|_+$/, '')
+    end
+  end
+end

--- a/sidereal.gemspec
+++ b/sidereal.gemspec
@@ -40,6 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'datastar', '~> 1.0.4'
   spec.add_dependency 'brotli'
   spec.add_dependency 'async'
+  spec.add_dependency 'fugit'
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -302,11 +302,13 @@ RSpec.describe 'Sidereal::App.schedule' do
 
   it 'delegates to the App.commander and registers with Sidereal.scheduler' do
     Class.new(Sidereal::App) do
-      schedule '*/5 * * * *' do
+      schedule 'Every 5 min', '*/5 * * * *' do
       end
     end
 
     expect(Sidereal.scheduler.schedules.size).to eq(1)
-    expect(Sidereal.scheduler.schedules.first.cron_expr).to eq('*/5 * * * *')
+    sch = Sidereal.scheduler.schedules.first
+    expect(sch.name).to eq('Every 5 min')
+    expect(sch.cron_expr).to eq('*/5 * * * *')
   end
 end

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -292,3 +292,21 @@ RSpec.describe 'Sidereal::App.handle' do
     end
   end
 end
+
+# Thin App-level test — App.schedule delegates to its commander, which has
+# the Scheduling mixin. Behaviour of the TriggerSchedule handler is covered
+# in commander_spec.rb.
+RSpec.describe 'Sidereal::App.schedule' do
+  before { Sidereal.reset_scheduler! }
+  after { Sidereal.reset_scheduler! }
+
+  it 'delegates to the App.commander and registers with Sidereal.scheduler' do
+    Class.new(Sidereal::App) do
+      schedule '*/5 * * * *' do
+      end
+    end
+
+    expect(Sidereal.scheduler.schedules.size).to eq(1)
+    expect(Sidereal.scheduler.schedules.first.cron_expr).to eq('*/5 * * * *')
+  end
+end

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -304,15 +304,15 @@ RSpec.describe 'Sidereal::App.schedule' do
     Object.const_set(:AppSchedTestApp, Class.new(Sidereal::App))
     AppSchedTestApp.class_eval do
       schedule 'Every 5 min' do
-        run_at '*/5 * * * *' do |_cmd|
+        at '*/5 * * * *' do |_cmd|
         end
       end
     end
 
     expect(Sidereal.scheduler.schedules.size).to eq(1)
     sch = Sidereal.scheduler.schedules.first
-    expect(sch.expression).to eq('*/5 * * * *')
-    expect(AppSchedTestApp.commander::Schedules.const_defined?(:SchedEvery5Min0Run, false)).to be true
+    expect(sch.steps.first.expression).to eq('*/5 * * * *')
+    expect(AppSchedTestApp.commander::Schedules.const_defined?(:SchedEvery5Min0Step0, false)).to be true
   ensure
     Object.send(:remove_const, :AppSchedTestApp) if Object.const_defined?(:AppSchedTestApp, false)
   end

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -301,14 +301,19 @@ RSpec.describe 'Sidereal::App.schedule' do
   after { Sidereal.reset_scheduler! }
 
   it 'delegates to the App.commander and registers with Sidereal.scheduler' do
-    Class.new(Sidereal::App) do
-      schedule 'Every 5 min', '*/5 * * * *' do
+    Object.const_set(:AppSchedTestApp, Class.new(Sidereal::App))
+    AppSchedTestApp.class_eval do
+      schedule 'Every 5 min' do
+        run_at '*/5 * * * *' do |_cmd|
+        end
       end
     end
 
     expect(Sidereal.scheduler.schedules.size).to eq(1)
     sch = Sidereal.scheduler.schedules.first
-    expect(sch.name).to eq('Every 5 min')
-    expect(sch.cron_expr).to eq('*/5 * * * *')
+    expect(sch.expression).to eq('*/5 * * * *')
+    expect(AppSchedTestApp.commander::Schedules.const_defined?(:SchedEvery5Min0Run, false)).to be true
+  ensure
+    Object.send(:remove_const, :AppSchedTestApp) if Object.const_defined?(:AppSchedTestApp, false)
   end
 end

--- a/spec/commander_spec.rb
+++ b/spec/commander_spec.rb
@@ -20,6 +20,10 @@ TestNotification = Sidereal::Message.define('test.notification') do
   attribute :text, Sidereal::Types::String
 end
 
+TestSchedTick = Sidereal::Message.define('test.sched_tick') do
+  attribute :n, Sidereal::Types::Integer
+end
+
 # -- Fake pubsub --
 
 class FakePubSub
@@ -74,6 +78,55 @@ RSpec.describe Sidereal::Commander do
 
       cmd = TestAddItem.new(payload: { title: 'test' })
       expect { cmdr_class.handle(cmd, pubsub: pubsub) }.not_to raise_error
+    end
+  end
+
+  describe '.schedule (Scheduling mixin)' do
+    before { Sidereal.reset_scheduler! }
+    after { Sidereal.reset_scheduler! }
+
+    it 'registers the schedule with Sidereal.scheduler' do
+      Class.new(Sidereal::Commander) do
+        schedule '*/5 * * * *' do
+        end
+      end
+
+      expect(Sidereal.scheduler.schedules.size).to eq(1)
+      expect(Sidereal.scheduler.schedules.first.cron_expr).to eq('*/5 * * * *')
+    end
+
+    it 'installs a TriggerSchedule handler that runs the schedule block in the commander instance and yields the cmd' do
+      cmdr_class = Class.new(Sidereal::Commander) do
+        command TestSchedTick do |_cmd|
+          # registered so dispatch routes TestSchedTick to commands, not events
+        end
+        schedule '*/5 * * * *' do |cmd|
+          # Read the producer from the cmd's metadata to prove the cmd is yielded.
+          dispatch TestSchedTick, n: cmd.metadata[:producer].length
+        end
+      end
+
+      sch = Sidereal.scheduler.schedules.first
+      trigger = Sidereal::System::TriggerSchedule.new(
+        payload: { schedule_id: sch.id },
+        metadata: { producer: sch.name }
+      )
+      result = cmdr_class.handle(trigger, pubsub: pubsub)
+
+      expect(result.commands.size).to eq(1)
+      dispatched = result.commands.first
+      expect(dispatched).to be_a(TestSchedTick)
+      expect(dispatched.payload.n).to eq(sch.name.length)
+      # Causation chain: the dispatched command points back at the TriggerSchedule.
+      expect(dispatched.causation_id).to eq(trigger.id)
+      expect(dispatched.correlation_id).to eq(trigger.correlation_id)
+    end
+
+    it 'is a no-op when the schedule_id is unknown (e.g. removed between dispatch and handle)' do
+      cmdr_class = Class.new(Sidereal::Commander)
+
+      trigger = Sidereal::System::TriggerSchedule.new(payload: { schedule_id: 999 })
+      expect { cmdr_class.handle(trigger, pubsub: pubsub) }.not_to raise_error
     end
   end
 

--- a/spec/commander_spec.rb
+++ b/spec/commander_spec.rb
@@ -87,12 +87,14 @@ RSpec.describe Sidereal::Commander do
 
     it 'registers the schedule with Sidereal.scheduler' do
       Class.new(Sidereal::Commander) do
-        schedule '*/5 * * * *' do
+        schedule 'Every 5 min', '*/5 * * * *' do
         end
       end
 
       expect(Sidereal.scheduler.schedules.size).to eq(1)
-      expect(Sidereal.scheduler.schedules.first.cron_expr).to eq('*/5 * * * *')
+      sch = Sidereal.scheduler.schedules.first
+      expect(sch.name).to eq('Every 5 min')
+      expect(sch.cron_expr).to eq('*/5 * * * *')
     end
 
     it 'installs a TriggerSchedule handler that runs the schedule block in the commander instance and yields the cmd' do
@@ -100,7 +102,7 @@ RSpec.describe Sidereal::Commander do
         command TestSchedTick do |_cmd|
           # registered so dispatch routes TestSchedTick to commands, not events
         end
-        schedule '*/5 * * * *' do |cmd|
+        schedule 'Recurring cleanup', '*/5 * * * *' do |cmd|
           # Read the producer from the cmd's metadata to prove the cmd is yielded.
           dispatch TestSchedTick, n: cmd.metadata[:producer].length
         end
@@ -108,24 +110,28 @@ RSpec.describe Sidereal::Commander do
 
       sch = Sidereal.scheduler.schedules.first
       trigger = Sidereal::System::TriggerSchedule.new(
-        payload: { schedule_id: sch.id },
-        metadata: { producer: sch.name }
+        payload: { schedule_id: sch.id, schedule_name: sch.name },
+        metadata: { producer: sch.producer_label }
       )
       result = cmdr_class.handle(trigger, pubsub: pubsub)
 
       expect(result.commands.size).to eq(1)
       dispatched = result.commands.first
       expect(dispatched).to be_a(TestSchedTick)
-      expect(dispatched.payload.n).to eq(sch.name.length)
+      expect(dispatched.payload.n).to eq(sch.producer_label.length)
       # Causation chain: the dispatched command points back at the TriggerSchedule.
       expect(dispatched.causation_id).to eq(trigger.id)
       expect(dispatched.correlation_id).to eq(trigger.correlation_id)
+      # Producer label propagates to the dispatched command via #correlate.
+      expect(dispatched.metadata[:producer]).to eq("Schedule #0 'Recurring cleanup' (*/5 * * * *)")
     end
 
     it 'is a no-op when the schedule_id is unknown (e.g. removed between dispatch and handle)' do
       cmdr_class = Class.new(Sidereal::Commander)
 
-      trigger = Sidereal::System::TriggerSchedule.new(payload: { schedule_id: 999 })
+      trigger = Sidereal::System::TriggerSchedule.new(
+        payload: { schedule_id: 999, schedule_name: 'gone' }
+      )
       expect { cmdr_class.handle(trigger, pubsub: pubsub) }.not_to raise_error
     end
   end

--- a/spec/commander_spec.rb
+++ b/spec/commander_spec.rb
@@ -20,12 +20,6 @@ TestNotification = Sidereal::Message.define('test.notification') do
   attribute :text, Sidereal::Types::String
 end
 
-TestSchedTick = Sidereal::Message.define('test.sched_tick') do
-  attribute :n, Sidereal::Types::Integer
-end
-
-TestSchedExit = Sidereal::Message.define('test.sched_exit')
-
 # -- Fake pubsub --
 
 class FakePubSub
@@ -84,248 +78,32 @@ RSpec.describe Sidereal::Commander do
   end
 
   describe '.schedule (Scheduling mixin)' do
+    # Heavy DSL coverage lives in spec/scheduling_spec.rb against a
+    # minimal stand-in host. These tests only verify the Commander's
+    # wiring to the mixin: it's included, and a registered schedule
+    # makes it onto +Sidereal.scheduler+ with the right shape.
     before { Sidereal.reset_scheduler! }
-    after { Sidereal.reset_scheduler! }
+    after  { Sidereal.reset_scheduler! }
 
-    # Give each anonymous Commander a distinct toplevel name so the
-    # auto-generated type strings don't collide across examples.
-    # The constant is set BEFORE the body runs so +self.name+ is
-    # already populated when +schedule+ derives type strings.
-    def named_commander(const_name, &body)
-      cls = Class.new(Sidereal::Commander)
-      Object.const_set(const_name, cls)
-      cls.class_eval(&body) if body
-      cls
+    it 'is included in Sidereal::Commander' do
+      expect(Sidereal::Commander.included_modules).to include(Sidereal::Scheduling)
     end
 
-    after do
-      %i[CmdrA CmdrB CmdrC CmdrD CmdrE CmdrF].each do |c|
-        Object.send(:remove_const, c) if Object.const_defined?(c, false)
-      end
-    end
-
-    describe 'single-step shorthand (name, expression, &block)' do
-      it 'registers a one-step schedule with the block as that step’s handler' do
-        cmdr = named_commander(:CmdrA) do
-          schedule 'Cleanup', '*/5 * * * *' do |_cmd|
-          end
-        end
-
-        expect(cmdr::Schedules.const_defined?(:SchedCleanup0Step0, false)).to be true
-
-        sch = Sidereal.scheduler.schedules.first
-        expect(sch.name).to eq('Cleanup')
-        expect(sch.steps.size).to eq(1)
-        expect(sch.steps.first.expression).to eq('*/5 * * * *')
-        expect(sch.steps.first.klass).to eq(cmdr::Schedules::SchedCleanup0Step0)
-      end
-
-      it 'yields the cmd to the user block (regular command handler)' do
-        named_commander(:CmdrB) do
-          command TestSchedTick do |_cmd| end
-          schedule 'Cleanup', '*/5 * * * *' do |cmd|
-            dispatch TestSchedTick, n: cmd.metadata[:schedule_name].length
-          end
-        end
-
-        run_cmd = CmdrB::Schedules::SchedCleanup0Step0.new(
-          metadata: { schedule_name: 'Cleanup' }
-        )
-        result = CmdrB.handle(run_cmd, pubsub: pubsub)
-
-        expect(result.commands.first).to be_a(TestSchedTick)
-        expect(result.commands.first.payload.n).to eq('Cleanup'.length)
-      end
-
-      it 'accepts a Time instance as the shorthand expression' do
-        target = Time.local(2026, 5, 4, 12, 0, 0)
-        named_commander(:CmdrC) do
-          schedule 'Once', target do |_cmd| end
-        end
-
-        sch = Sidereal.scheduler.schedules.first
-        expect(sch.steps.first.at).to eq(target)
-      end
-
-      it 'raises if the shorthand block has the wrong arity' do
-        expect {
-          named_commander(:CmdrD) do
-            schedule 'Bad', '*/5 * * * *' do
-              # arity 0 with an expression — invalid for shorthand
-            end
-          end
-        }.to raise_error(ArgumentError, /requires a block of arity 1/)
-      end
-    end
-
-    describe 'block form (auto-generated step classes)' do
-      it 'generates one class per step under <Host>::Schedules and registers each with Sidereal.scheduler' do
-        cmdr = named_commander(:CmdrA) do
-          schedule 'Tick campaign' do
-            at '2026-05-06T15:00:00' do |_cmd| end
-            at 'every 3 seconds'    do |_cmd| end
-            at '30s'                do |_cmd| end
-          end
-        end
-
-        expect(cmdr::Schedules.const_defined?(:SchedTickCampaign0Step0, false)).to be true
-        expect(cmdr::Schedules.const_defined?(:SchedTickCampaign0Step1, false)).to be true
-        expect(cmdr::Schedules.const_defined?(:SchedTickCampaign0Step2, false)).to be true
-
-        step0 = cmdr::Schedules::SchedTickCampaign0Step0
-        expect(step0.type).to eq('cmdr_a.schedules.tick_campaign_0_step_0')
-
-        sch = Sidereal.scheduler.schedules.first
-        expect(sch.name).to eq('Tick campaign')
-        expect(sch.steps.map(&:klass)).to eq([
-          cmdr::Schedules::SchedTickCampaign0Step0,
-          cmdr::Schedules::SchedTickCampaign0Step1,
-          cmdr::Schedules::SchedTickCampaign0Step2
-        ])
-      end
-
-      it 'wires the user block as the handler for the generated step class and propagates schedule_name via metadata' do
-        named_commander(:CmdrB) do
-          command TestSchedTick do |_cmd| end
-          schedule 'Cleanup' do
-            at '*/5 * * * *' do |cmd|
-              dispatch TestSchedTick, n: cmd.metadata[:schedule_name].length
-            end
-          end
-        end
-
-        step_cmd = CmdrB::Schedules::SchedCleanup0Step0.new(
-          metadata: { schedule_name: 'Cleanup', producer: "Schedule #0 'Cleanup' step #0 (*/5 * * * *)" }
-        )
-        result = CmdrB.handle(step_cmd, pubsub: pubsub)
-
-        expect(result.commands.size).to eq(1)
-        dispatched = result.commands.first
-        expect(dispatched).to be_a(TestSchedTick)
-        expect(dispatched.payload.n).to eq('Cleanup'.length)
-        expect(dispatched.causation_id).to eq(step_cmd.id)
-        expect(dispatched.metadata[:schedule_name]).to eq('Cleanup')
-      end
-    end
-
-    describe 'explicit-class form (klass + payload, no block)' do
-      it 'passes the user-supplied class through to the Scheduler without generating a class or handler' do
-        cmdr = named_commander(:CmdrA) do
-          schedule 'Flash sale campaign' do
-            at '2026-05-10T10:00:00', TestSchedTick, n: 1
-            at 'every day at 9am',    TestSchedTick, n: 2
-            at '10d',                 TestSchedExit
-          end
-        end
-
-        expect(cmdr::Schedules.constants).to be_empty
-
-        sch = Sidereal.scheduler.schedules.first
-        expect(sch.name).to eq('Flash sale campaign')
-        expect(sch.steps.size).to eq(3)
-        expect(sch.steps[0].klass).to eq(TestSchedTick)
-        expect(sch.steps[0].payload).to eq(n: 1)
-        expect(sch.steps[2].klass).to eq(TestSchedExit)
-        expect(sch.steps[2].payload).to eq({})
-      end
-
-      it 'allows mixing block and explicit forms across steps' do
-        cmdr = named_commander(:CmdrB) do
-          command TestSchedExit do |_cmd| end
-          schedule 'Mixed' do
-            at '2026-05-10T10:00:00' do |_cmd| end                # generated
-            at 'every minute', TestSchedTick, n: 1                # explicit
-            at '1h', TestSchedExit                                # explicit
-          end
-        end
-
-        expect(cmdr::Schedules.const_defined?(:SchedMixed0Step0, false)).to be true
-        expect(cmdr::Schedules.const_defined?(:SchedMixed0Step1, false)).to be false
-        expect(cmdr::Schedules.const_defined?(:SchedMixed0Step2, false)).to be false
-
-        sch = Sidereal.scheduler.schedules.first
-        expect(sch.steps[1].klass).to eq(TestSchedTick)
-        expect(sch.steps[2].klass).to eq(TestSchedExit)
-      end
-
-      it 'raises when both a block and a class are supplied to the same at' do
-        expect {
-          named_commander(:CmdrC) do
-            schedule 'Both' do
-              at 'every minute', TestSchedTick, n: 1 do |_cmd| end
-            end
-          end
-        }.to raise_error(ArgumentError, /pass either a block or a command class, not both/)
-      end
-
-      it 'a recurring step with neither a block nor a class raises (bound-only recurring is meaningless)' do
-        expect {
-          named_commander(:CmdrD) do
-            schedule 'BadMarker' do
-              at 'every minute'
-            end
-          end
-        }.to raise_error(ArgumentError, /recurring step.*requires a command class/)
-      end
-
-      it 'a specific or duration step with no class is a bound-only marker (anchors the timeline, never dispatches)' do
-        cmdr = named_commander(:CmdrA) do
-          schedule 'Campaign' do
-            at '2026-05-04T10:00:00'                       # marker — no class
-            at '*/5 * * * *', TestSchedTick, n: 1          # recurring anchored to the marker
-          end
-        end
-
-        # No class generated for the marker; only the recurring step
-        # uses an explicit class so nothing under Schedules.
-        expect(cmdr::Schedules.constants).to be_empty
-
-        sch = Sidereal.scheduler.schedules.first
-        expect(sch.steps[0].klass).to be_nil
-        expect(sch.steps[0].at).to eq(Time.parse('2026-05-04T10:00:00'))
-        expect(sch.steps[1].klass).to eq(TestSchedTick)
-        expect(sch.steps[1].from).to eq(Time.parse('2026-05-04T10:00:00'))
-      end
-    end
-
-    it 'raises if the schedule block has no at calls' do
-      expect {
-        named_commander(:CmdrA) do
-          schedule 'Empty' do
-            # no at(...) calls
-          end
-        end
-      }.to raise_error(ArgumentError, /must declare at least one at/)
-    end
-
-    it 'raises if the schedule block takes arguments (must use the inner DSL)' do
-      expect {
-        named_commander(:CmdrE) do
-          schedule 'Bad' do |_cmd|
-          end
-        end
-      }.to raise_error(ArgumentError, /block must take no arguments/)
-    end
-
-    it 'each subclass of Commander gets its own Schedules namespace' do
-      a = named_commander(:CmdrA) {}
-      b = named_commander(:CmdrB) {}
-
-      expect(a::Schedules).not_to equal(b::Schedules)
-      expect(a::Schedules).not_to equal(Sidereal::Commander::Schedules)
-    end
-
-    it 'survives a schedule name that starts with a digit (Sched prefix keeps the constant valid)' do
-      Object.const_set(:CmdrF, Class.new(Sidereal::Commander))
-      CmdrF.class_eval do
-        schedule '5 minute' do
-          at '*/5 * * * *' do |_cmd| end
+    it 'registers a schedule on Sidereal.scheduler with the configured data' do
+      Object.const_set(:CmdrSchedTest, Class.new(Sidereal::Commander))
+      CmdrSchedTest.class_eval do
+        schedule 'My sched', '*/5 * * * *' do |_cmd|
         end
       end
 
-      expect(CmdrF::Schedules.const_defined?(:Sched5Minute0Step0, false)).to be true
+      expect(Sidereal.scheduler.schedules.size).to eq(1)
+      sch = Sidereal.scheduler.schedules.first
+      expect(sch.name).to eq('My sched')
+      expect(sch.steps.size).to eq(1)
+      expect(sch.steps.first.expression).to eq('*/5 * * * *')
+      expect(sch.steps.first.klass).to eq(CmdrSchedTest::Schedules::SchedMySched0Step0)
     ensure
-      Object.send(:remove_const, :CmdrF) if Object.const_defined?(:CmdrF, false)
+      Object.send(:remove_const, :CmdrSchedTest) if Object.const_defined?(:CmdrSchedTest, false)
     end
   end
 

--- a/spec/commander_spec.rb
+++ b/spec/commander_spec.rb
@@ -104,6 +104,60 @@ RSpec.describe Sidereal::Commander do
       end
     end
 
+    describe 'single-step shorthand (name, expression, &block)' do
+      it 'registers a one-step schedule with the block as that step’s handler' do
+        cmdr = named_commander(:CmdrA) do
+          schedule 'Cleanup', '*/5 * * * *' do |_cmd|
+          end
+        end
+
+        expect(cmdr::Schedules.const_defined?(:SchedCleanup0Step0, false)).to be true
+
+        sch = Sidereal.scheduler.schedules.first
+        expect(sch.name).to eq('Cleanup')
+        expect(sch.steps.size).to eq(1)
+        expect(sch.steps.first.expression).to eq('*/5 * * * *')
+        expect(sch.steps.first.klass).to eq(cmdr::Schedules::SchedCleanup0Step0)
+      end
+
+      it 'yields the cmd to the user block (regular command handler)' do
+        named_commander(:CmdrB) do
+          command TestSchedTick do |_cmd| end
+          schedule 'Cleanup', '*/5 * * * *' do |cmd|
+            dispatch TestSchedTick, n: cmd.metadata[:schedule_name].length
+          end
+        end
+
+        run_cmd = CmdrB::Schedules::SchedCleanup0Step0.new(
+          metadata: { schedule_name: 'Cleanup' }
+        )
+        result = CmdrB.handle(run_cmd, pubsub: pubsub)
+
+        expect(result.commands.first).to be_a(TestSchedTick)
+        expect(result.commands.first.payload.n).to eq('Cleanup'.length)
+      end
+
+      it 'accepts a Time instance as the shorthand expression' do
+        target = Time.local(2026, 5, 4, 12, 0, 0)
+        named_commander(:CmdrC) do
+          schedule 'Once', target do |_cmd| end
+        end
+
+        sch = Sidereal.scheduler.schedules.first
+        expect(sch.steps.first.at).to eq(target)
+      end
+
+      it 'raises if the shorthand block has the wrong arity' do
+        expect {
+          named_commander(:CmdrD) do
+            schedule 'Bad', '*/5 * * * *' do
+              # arity 0 with an expression — invalid for shorthand
+            end
+          end
+        }.to raise_error(ArgumentError, /requires a block of arity 1/)
+      end
+    end
+
     describe 'block form (auto-generated step classes)' do
       it 'generates one class per step under <Host>::Schedules and registers each with Sidereal.scheduler' do
         cmdr = named_commander(:CmdrA) do

--- a/spec/commander_spec.rb
+++ b/spec/commander_spec.rb
@@ -24,6 +24,8 @@ TestSchedTick = Sidereal::Message.define('test.sched_tick') do
   attribute :n, Sidereal::Types::Integer
 end
 
+TestSchedExit = Sidereal::Message.define('test.sched_exit')
+
 # -- Fake pubsub --
 
 class FakePubSub
@@ -85,54 +87,191 @@ RSpec.describe Sidereal::Commander do
     before { Sidereal.reset_scheduler! }
     after { Sidereal.reset_scheduler! }
 
-    it 'registers the schedule with Sidereal.scheduler' do
-      Class.new(Sidereal::Commander) do
-        schedule 'Every 5 min', '*/5 * * * *' do
+    # Give each anonymous Commander a distinct toplevel name so the
+    # auto-generated type strings don't collide across examples.
+    # The constant is set BEFORE the body runs so +self.name+ is
+    # already populated when +schedule+ derives type strings.
+    def named_commander(const_name, &body)
+      cls = Class.new(Sidereal::Commander)
+      Object.const_set(const_name, cls)
+      cls.class_eval(&body) if body
+      cls
+    end
+
+    after do
+      %i[CmdrA CmdrB CmdrC CmdrD CmdrE CmdrF].each do |c|
+        Object.send(:remove_const, c) if Object.const_defined?(c, false)
+      end
+    end
+
+    describe 'block form (auto-generated step classes)' do
+      it 'generates one class per step under <Host>::Schedules and registers each with Sidereal.scheduler' do
+        cmdr = named_commander(:CmdrA) do
+          schedule 'Tick campaign' do
+            at '2026-05-06T15:00:00' do |_cmd| end
+            at 'every 3 seconds'    do |_cmd| end
+            at '30s'                do |_cmd| end
+          end
+        end
+
+        expect(cmdr::Schedules.const_defined?(:SchedTickCampaign0Step0, false)).to be true
+        expect(cmdr::Schedules.const_defined?(:SchedTickCampaign0Step1, false)).to be true
+        expect(cmdr::Schedules.const_defined?(:SchedTickCampaign0Step2, false)).to be true
+
+        step0 = cmdr::Schedules::SchedTickCampaign0Step0
+        expect(step0.type).to eq('cmdr_a.schedules.tick_campaign_0_step_0')
+
+        sch = Sidereal.scheduler.schedules.first
+        expect(sch.name).to eq('Tick campaign')
+        expect(sch.steps.map(&:klass)).to eq([
+          cmdr::Schedules::SchedTickCampaign0Step0,
+          cmdr::Schedules::SchedTickCampaign0Step1,
+          cmdr::Schedules::SchedTickCampaign0Step2
+        ])
+      end
+
+      it 'wires the user block as the handler for the generated step class and propagates schedule_name via metadata' do
+        named_commander(:CmdrB) do
+          command TestSchedTick do |_cmd| end
+          schedule 'Cleanup' do
+            at '*/5 * * * *' do |cmd|
+              dispatch TestSchedTick, n: cmd.metadata[:schedule_name].length
+            end
+          end
+        end
+
+        step_cmd = CmdrB::Schedules::SchedCleanup0Step0.new(
+          metadata: { schedule_name: 'Cleanup', producer: "Schedule #0 'Cleanup' step #0 (*/5 * * * *)" }
+        )
+        result = CmdrB.handle(step_cmd, pubsub: pubsub)
+
+        expect(result.commands.size).to eq(1)
+        dispatched = result.commands.first
+        expect(dispatched).to be_a(TestSchedTick)
+        expect(dispatched.payload.n).to eq('Cleanup'.length)
+        expect(dispatched.causation_id).to eq(step_cmd.id)
+        expect(dispatched.metadata[:schedule_name]).to eq('Cleanup')
+      end
+    end
+
+    describe 'explicit-class form (klass + payload, no block)' do
+      it 'passes the user-supplied class through to the Scheduler without generating a class or handler' do
+        cmdr = named_commander(:CmdrA) do
+          schedule 'Flash sale campaign' do
+            at '2026-05-10T10:00:00', TestSchedTick, n: 1
+            at 'every day at 9am',    TestSchedTick, n: 2
+            at '10d',                 TestSchedExit
+          end
+        end
+
+        expect(cmdr::Schedules.constants).to be_empty
+
+        sch = Sidereal.scheduler.schedules.first
+        expect(sch.name).to eq('Flash sale campaign')
+        expect(sch.steps.size).to eq(3)
+        expect(sch.steps[0].klass).to eq(TestSchedTick)
+        expect(sch.steps[0].payload).to eq(n: 1)
+        expect(sch.steps[2].klass).to eq(TestSchedExit)
+        expect(sch.steps[2].payload).to eq({})
+      end
+
+      it 'allows mixing block and explicit forms across steps' do
+        cmdr = named_commander(:CmdrB) do
+          command TestSchedExit do |_cmd| end
+          schedule 'Mixed' do
+            at '2026-05-10T10:00:00' do |_cmd| end                # generated
+            at 'every minute', TestSchedTick, n: 1                # explicit
+            at '1h', TestSchedExit                                # explicit
+          end
+        end
+
+        expect(cmdr::Schedules.const_defined?(:SchedMixed0Step0, false)).to be true
+        expect(cmdr::Schedules.const_defined?(:SchedMixed0Step1, false)).to be false
+        expect(cmdr::Schedules.const_defined?(:SchedMixed0Step2, false)).to be false
+
+        sch = Sidereal.scheduler.schedules.first
+        expect(sch.steps[1].klass).to eq(TestSchedTick)
+        expect(sch.steps[2].klass).to eq(TestSchedExit)
+      end
+
+      it 'raises when both a block and a class are supplied to the same at' do
+        expect {
+          named_commander(:CmdrC) do
+            schedule 'Both' do
+              at 'every minute', TestSchedTick, n: 1 do |_cmd| end
+            end
+          end
+        }.to raise_error(ArgumentError, /pass either a block or a command class, not both/)
+      end
+
+      it 'a recurring step with neither a block nor a class raises (bound-only recurring is meaningless)' do
+        expect {
+          named_commander(:CmdrD) do
+            schedule 'BadMarker' do
+              at 'every minute'
+            end
+          end
+        }.to raise_error(ArgumentError, /recurring step.*requires a command class/)
+      end
+
+      it 'a specific or duration step with no class is a bound-only marker (anchors the timeline, never dispatches)' do
+        cmdr = named_commander(:CmdrA) do
+          schedule 'Campaign' do
+            at '2026-05-04T10:00:00'                       # marker — no class
+            at '*/5 * * * *', TestSchedTick, n: 1          # recurring anchored to the marker
+          end
+        end
+
+        # No class generated for the marker; only the recurring step
+        # uses an explicit class so nothing under Schedules.
+        expect(cmdr::Schedules.constants).to be_empty
+
+        sch = Sidereal.scheduler.schedules.first
+        expect(sch.steps[0].klass).to be_nil
+        expect(sch.steps[0].at).to eq(Time.parse('2026-05-04T10:00:00'))
+        expect(sch.steps[1].klass).to eq(TestSchedTick)
+        expect(sch.steps[1].from).to eq(Time.parse('2026-05-04T10:00:00'))
+      end
+    end
+
+    it 'raises if the schedule block has no at calls' do
+      expect {
+        named_commander(:CmdrA) do
+          schedule 'Empty' do
+            # no at(...) calls
+          end
+        end
+      }.to raise_error(ArgumentError, /must declare at least one at/)
+    end
+
+    it 'raises if the schedule block takes arguments (must use the inner DSL)' do
+      expect {
+        named_commander(:CmdrE) do
+          schedule 'Bad' do |_cmd|
+          end
+        end
+      }.to raise_error(ArgumentError, /block must take no arguments/)
+    end
+
+    it 'each subclass of Commander gets its own Schedules namespace' do
+      a = named_commander(:CmdrA) {}
+      b = named_commander(:CmdrB) {}
+
+      expect(a::Schedules).not_to equal(b::Schedules)
+      expect(a::Schedules).not_to equal(Sidereal::Commander::Schedules)
+    end
+
+    it 'survives a schedule name that starts with a digit (Sched prefix keeps the constant valid)' do
+      Object.const_set(:CmdrF, Class.new(Sidereal::Commander))
+      CmdrF.class_eval do
+        schedule '5 minute' do
+          at '*/5 * * * *' do |_cmd| end
         end
       end
 
-      expect(Sidereal.scheduler.schedules.size).to eq(1)
-      sch = Sidereal.scheduler.schedules.first
-      expect(sch.name).to eq('Every 5 min')
-      expect(sch.cron_expr).to eq('*/5 * * * *')
-    end
-
-    it 'installs a TriggerSchedule handler that runs the schedule block in the commander instance and yields the cmd' do
-      cmdr_class = Class.new(Sidereal::Commander) do
-        command TestSchedTick do |_cmd|
-          # registered so dispatch routes TestSchedTick to commands, not events
-        end
-        schedule 'Recurring cleanup', '*/5 * * * *' do |cmd|
-          # Read the producer from the cmd's metadata to prove the cmd is yielded.
-          dispatch TestSchedTick, n: cmd.metadata[:producer].length
-        end
-      end
-
-      sch = Sidereal.scheduler.schedules.first
-      trigger = Sidereal::System::TriggerSchedule.new(
-        payload: { schedule_id: sch.id, schedule_name: sch.name },
-        metadata: { producer: sch.producer_label }
-      )
-      result = cmdr_class.handle(trigger, pubsub: pubsub)
-
-      expect(result.commands.size).to eq(1)
-      dispatched = result.commands.first
-      expect(dispatched).to be_a(TestSchedTick)
-      expect(dispatched.payload.n).to eq(sch.producer_label.length)
-      # Causation chain: the dispatched command points back at the TriggerSchedule.
-      expect(dispatched.causation_id).to eq(trigger.id)
-      expect(dispatched.correlation_id).to eq(trigger.correlation_id)
-      # Producer label propagates to the dispatched command via #correlate.
-      expect(dispatched.metadata[:producer]).to eq("Schedule #0 'Recurring cleanup' (*/5 * * * *)")
-    end
-
-    it 'is a no-op when the schedule_id is unknown (e.g. removed between dispatch and handle)' do
-      cmdr_class = Class.new(Sidereal::Commander)
-
-      trigger = Sidereal::System::TriggerSchedule.new(
-        payload: { schedule_id: 999, schedule_name: 'gone' }
-      )
-      expect { cmdr_class.handle(trigger, pubsub: pubsub) }.not_to raise_error
+      expect(CmdrF::Schedules.const_defined?(:Sched5Minute0Step0, false)).to be true
+    ensure
+      Object.send(:remove_const, :CmdrF) if Object.const_defined?(:CmdrF, false)
     end
   end
 

--- a/spec/elector_spec.rb
+++ b/spec/elector_spec.rb
@@ -1,0 +1,212 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'sidereal/elector/file_system'
+require 'tmpdir'
+
+# Test elector that exposes promote!/demote! to drive transitions
+# from specs without spawning a real election fiber.
+class TestElector
+  include Sidereal::Elector::Callbacks
+
+  def initialize
+    @leader = false
+  end
+
+  def leader? = @leader
+  def start(_task) = self
+  def promote! = super
+  def demote! = super
+end
+
+RSpec.describe Sidereal::Elector do
+  describe Sidereal::Elector::AlwaysLeader do
+    subject(:elector) { described_class.new }
+
+    it 'is leader from construction' do
+      expect(elector.leader?).to be true
+    end
+
+    it 'fires on_promote immediately at registration' do
+      called = false
+      elector.on_promote { called = true }
+      expect(called).to be true
+    end
+
+    it 'does not fire on_demote at registration when leader' do
+      called = false
+      elector.on_demote { called = true }
+      expect(called).to be false
+    end
+
+    it 'returns self for chaining from on_promote/on_demote' do
+      expect(elector.on_promote {}).to eq(elector)
+      expect(elector.on_demote {}).to eq(elector)
+    end
+
+    it '#start is a no-op that returns self' do
+      expect(elector.start(:fake_task)).to eq(elector)
+    end
+  end
+
+  describe 'Callbacks mixin (transition semantics)' do
+    subject(:elector) { TestElector.new }
+
+    it 'fires on_demote at registration when not yet leader' do
+      called = false
+      elector.on_demote { called = true }
+      expect(called).to be true
+    end
+
+    it 'does not fire on_promote at registration when not yet leader' do
+      called = false
+      elector.on_promote { called = true }
+      expect(called).to be false
+    end
+
+    it 'fires on_promote on the follower→leader transition' do
+      fired = []
+      elector.on_promote { fired << :promoted }
+      elector.promote!
+      expect(fired).to eq([:promoted])
+    end
+
+    it 'fires on_demote on the leader→follower transition' do
+      elector.promote!
+      fired = []
+      elector.on_demote { fired << :demoted }
+      elector.promote!     # already leader: no-op
+      elector.demote!
+      expect(fired).to eq([:demoted])
+    end
+
+    it 'is idempotent: repeated promote!/demote! in same state fires once' do
+      promotions = 0
+      demotions = 0
+      elector.on_promote { promotions += 1 }
+      elector.on_demote { demotions += 1 }   # fires once at registration (not leader yet)
+
+      elector.promote!
+      elector.promote!     # no-op
+      elector.demote!
+      elector.demote!      # no-op
+
+      expect(promotions).to eq(1)
+      expect(demotions).to eq(2)   # one at registration, one on transition
+    end
+
+    it 'fires multiple callbacks in registration order' do
+      order = []
+      elector.on_promote { order << :first }
+      elector.on_promote { order << :second }
+      elector.promote!
+      expect(order).to eq([:first, :second])
+    end
+
+    it 'a raising callback does not block sibling callbacks' do
+      order = []
+      elector.on_promote { raise 'boom' }
+      elector.on_promote { order << :ran }
+      elector.promote!
+      expect(order).to eq([:ran])
+    end
+  end
+
+  describe Sidereal::Elector::FileSystem do
+    let(:lock_path) { File.join(Dir.mktmpdir('sidereal-elector-'), 'leader.lock') }
+
+    after { FileUtils.rm_rf(File.dirname(lock_path)) }
+
+    it 'creates the lock directory if missing' do
+      nested = File.join(Dir.mktmpdir, 'a', 'b', 'leader.lock')
+      described_class.new(lock_path: nested)
+      expect(Dir.exist?(File.dirname(nested))).to be true
+    end
+
+    it 'starts as follower; promotes once start fiber acquires the flock' do
+      elector = described_class.new(lock_path: lock_path, retry_interval: 0.05)
+      promoted = false
+      elector.on_promote { promoted = true }
+
+      expect(elector.leader?).to be false
+
+      Sync do |task|
+        elector.start(task)
+        # Give the election fiber a chance to run.
+        sleep 0.1
+        expect(elector.leader?).to be true
+        expect(promoted).to be true
+        task.stop
+      end
+    end
+
+    it 'second concurrent elector remains follower while first holds the lock' do
+      e1 = described_class.new(lock_path: lock_path, retry_interval: 0.05)
+      e2 = described_class.new(lock_path: lock_path, retry_interval: 0.05)
+      e2_promoted = false
+      e2.on_promote { e2_promoted = true }
+
+      Sync do |task|
+        e1.start(task)
+        sleep 0.1
+        expect(e1.leader?).to be true
+
+        e2.start(task)
+        sleep 0.2     # plenty of retry cycles
+        expect(e2.leader?).to be false
+        expect(e2_promoted).to be false
+
+        task.stop
+      end
+    end
+
+    it 'releases the lock and fires on_demote when the fiber is cancelled' do
+      elector = described_class.new(lock_path: lock_path, retry_interval: 0.05)
+      demoted = false
+      elector.on_promote { demoted = false }   # reset at promotion
+      elector.on_demote { demoted = true }     # fires once at registration (still false), then on shutdown
+
+      Sync do |task|
+        elector.start(task)
+        sleep 0.1
+        expect(elector.leader?).to be true
+        # demoted was reset to false at promotion via on_promote callback
+        expect(demoted).to be false
+
+        task.stop
+      end
+
+      # After the parent task stops, the elector's ensure block should
+      # have closed the lock file and fired on_demote.
+      expect(elector.leader?).to be false
+      expect(demoted).to be true
+    end
+
+    it 'a follower promotes after the prior leader releases its lock' do
+      e1 = described_class.new(lock_path: lock_path, retry_interval: 0.05)
+      e2 = described_class.new(lock_path: lock_path, retry_interval: 0.05)
+
+      Sync do |task|
+        e1.start(task)
+        e2.start(task)
+        sleep 0.1
+        expect(e1.leader?).to be true
+        expect(e2.leader?).to be false
+
+        # Voluntarily step down — releases the flock.
+        e1.stop
+        sleep 0.2     # let e2's poll cycle pick up the vacancy
+        expect(e1.leader?).to be false
+        expect(e2.leader?).to be true
+
+        task.stop
+      end
+    end
+  end
+
+  describe 'Sidereal.elector default' do
+    it 'defaults to AlwaysLeader' do
+      expect(Sidereal.elector).to be_a(Sidereal::Elector::AlwaysLeader)
+    end
+  end
+end

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -171,6 +171,42 @@ RSpec.describe Sidereal::Message do
       msg = bare_class.new
       expect { msg.at(Time.now - 60) }.to raise_error(Sidereal::PastMessageDateError)
     end
+
+    it 'accepts an Integer as seconds added to Time.now' do
+      msg = bare_class.new
+      before = Time.now
+      delayed = msg.at(60)
+      after = Time.now
+
+      expect(delayed.created_at).to be_within(1).of(before + 60)
+      expect(delayed.created_at).to be <= after + 60
+    end
+
+    it 'raises when given a negative Integer that resolves before created_at' do
+      msg = bare_class.new
+      expect { msg.at(-3600) }.to raise_error(Sidereal::PastMessageDateError)
+    end
+
+    it 'accepts a Fugit duration String added to Time.now' do
+      msg = bare_class.new
+      before = Time.now
+      delayed = msg.at('5m')
+      expect(delayed.created_at).to be_within(1).of(before + 5 * 60)
+    end
+
+    it 'accepts an ISO8601 duration String' do
+      msg = bare_class.new
+      before = Time.now
+      delayed = msg.at('PT1H30M')
+      expect(delayed.created_at).to be_within(1).of(before + 90 * 60)
+    end
+
+    it 'raises ArgumentError when the String is not a duration (e.g. a date)' do
+      msg = bare_class.new
+      expect {
+        msg.at('2026-12-31T10:00:00')
+      }.to raise_error(ArgumentError, /must be an ISO8601 \/ Fugit duration/)
+    end
   end
 
   describe '.from' do

--- a/spec/pubsub/unix_failover_spec.rb
+++ b/spec/pubsub/unix_failover_spec.rb
@@ -5,6 +5,7 @@ require 'async'
 require 'tmpdir'
 require 'json'
 require 'sidereal/pubsub/unix'
+require 'sidereal/elector/file_system'
 
 UnixFailoverMsg = Sidereal::Message.define('unix_failover_spec.event') do
   attribute :tag, Sidereal::Types::String
@@ -26,9 +27,12 @@ RSpec.describe 'Sidereal::PubSub::Unix cross-process' do
   def build_pubsub
     Sidereal::PubSub::Unix.new(
       socket_path: socket_path,
-      lock_path: lock_path,
       reconnect_min: 0.02,
-      reconnect_max: 0.05
+      reconnect_max: 0.05,
+      # Each forked process gets its own elector instance, racing on
+      # the shared lock_path — same topology as the old embedded
+      # election, just delegated.
+      elector: Sidereal::Elector::FileSystem.new(lock_path: lock_path, retry_interval: 0.05)
     )
   end
 
@@ -193,10 +197,7 @@ RSpec.describe 'Sidereal::PubSub::Unix cross-process' do
       # so the pubsub is never started and @client_socket is nil — the same
       # state a publisher would briefly observe between EOF and reconnect
       # during a failover. publish must tolerate it.
-      pubsub = Sidereal::PubSub::Unix.new(
-        socket_path: socket_path,
-        lock_path: lock_path
-      )
+      pubsub = Sidereal::PubSub::Unix.new(socket_path: socket_path)
       expect do
         pubsub.publish('any.thing', UnixFailoverMsg.new(payload: { tag: 'lost' }))
       end.not_to raise_error

--- a/spec/pubsub/unix_spec.rb
+++ b/spec/pubsub/unix_spec.rb
@@ -4,6 +4,7 @@ require 'spec_helper'
 require 'async'
 require 'tmpdir'
 require 'sidereal/pubsub/unix'
+require 'sidereal/elector/file_system'
 
 UnixPubSubMsg = Sidereal::Message.define('unix_pubsub_spec.event') do
   attribute :tag, Sidereal::Types::String
@@ -19,12 +20,12 @@ RSpec.describe Sidereal::PubSub::Unix do
     end
   end
 
-  def build_pubsub(**overrides)
+  def build_pubsub(elector: Sidereal::Elector::AlwaysLeader.new, **overrides)
     described_class.new(
       socket_path: File.join(@root, 'pubsub.sock'),
-      lock_path: File.join(@root, 'pubsub.lock'),
       reconnect_min: 0.01,
       reconnect_max: 0.02,
+      elector: elector,
       **overrides
     )
   end
@@ -194,30 +195,31 @@ RSpec.describe Sidereal::PubSub::Unix do
     it 'raises when the socket path is too long' do
       long_path = File.join(@root, 'a' * 200, 'pubsub.sock')
       expect do
-        described_class.new(socket_path: long_path, lock_path: File.join(@root, 'pubsub.lock'))
+        described_class.new(socket_path: long_path)
       end.to raise_error(ArgumentError, /too long/)
     end
   end
 
-  describe 'leader election' do
-    it 'lets exactly one of two pubsubs sharing a socket become leader' do
-      a = build_pubsub
-      b = build_pubsub
+  describe 'leader election (delegated to injected Elector)' do
+    it 'lets exactly one of two pubsubs sharing a lock file become broker' do
+      lock_path = File.join(@root, 'pubsub.lock')
+      e_a = Sidereal::Elector::FileSystem.new(lock_path: lock_path, retry_interval: 0.05)
+      e_b = Sidereal::Elector::FileSystem.new(lock_path: lock_path, retry_interval: 0.05)
+      a = build_pubsub(elector: e_a)
+      b = build_pubsub(elector: e_b)
 
       a_is_leader = nil
       b_is_leader = nil
 
       Sync do |task|
         a.start(task)
-        # Give A time to acquire flock and bind.
-        sleep 0.1
+        sleep 0.1     # let A acquire the flock and on_promote run
         b.start(task)
         sleep 0.1
 
         a_is_leader = a.leader?
         b_is_leader = b.leader?
 
-        # Tear down explicitly to avoid lingering fibers.
         task.stop
       end
 

--- a/spec/scheduler_spec.rb
+++ b/spec/scheduler_spec.rb
@@ -33,40 +33,54 @@ RSpec.describe Sidereal::Scheduler do
   subject(:scheduler) { described_class.new(clock: clock, store: store) }
 
   describe '#schedule' do
-    it 'parses the cron and adds an immutable Schedule with a monotonic integer id' do
-      scheduler.schedule('* * * * *') {}
-      scheduler.schedule('5 0 * * *') {}
-      scheduler.schedule('*/10 * * * *') {}
+    it 'parses the cron and adds an immutable Schedule with monotonic id and the supplied name' do
+      scheduler.schedule('Every minute', '* * * * *') {}
+      scheduler.schedule('Daily at 00:05', '5 0 * * *') {}
+      scheduler.schedule('Every 10 min', '*/10 * * * *') {}
 
-      ids = scheduler.schedules.map(&:id)
-      expect(ids).to eq([0, 1, 2])
+      expect(scheduler.schedules.map(&:id)).to eq([0, 1, 2])
+      expect(scheduler.schedules.map(&:name)).to eq(['Every minute', 'Daily at 00:05', 'Every 10 min'])
 
       first = scheduler.schedules.first
       expect(first).to be_frozen
       expect(first.cron_expr).to eq('* * * * *')
+      expect(first.name).to eq('Every minute')
     end
 
     it 'allows multiple schedules sharing the same cron expression' do
-      scheduler.schedule('5 0 * * *') {}
-      scheduler.schedule('5 0 * * *') {}
+      scheduler.schedule('A', '5 0 * * *') {}
+      scheduler.schedule('B', '5 0 * * *') {}
 
       expect(scheduler.schedules.size).to eq(2)
       expect(scheduler.schedules.map(&:id)).to eq([0, 1])
+      expect(scheduler.schedules.map(&:name)).to eq(['A', 'B'])
       expect(scheduler.schedules.map(&:cron_expr)).to eq(['5 0 * * *', '5 0 * * *'])
     end
 
     it 'raises ArgumentError on a malformed cron expression' do
-      expect { scheduler.schedule('not a cron') {} }.to raise_error(ArgumentError, /invalid cron/)
+      expect { scheduler.schedule('Bad', 'not a cron') {} }.to raise_error(ArgumentError, /invalid cron/)
+    end
+
+    it 'auto-names the schedule when only a cron_expr is supplied' do
+      scheduler.schedule('5 0 * * *') {}
+      scheduler.schedule('* * * * *') {}
+
+      expect(scheduler.schedules.map(&:name)).to eq(['0 (5 0 * * *)', '1 (* * * * *)'])
+    end
+
+    it 'raises on bad arity' do
+      expect { scheduler.schedule {} }.to raise_error(ArgumentError, /schedule takes/)
+      expect { scheduler.schedule('a', 'b', 'c') {} }.to raise_error(ArgumentError, /schedule takes/)
     end
   end
 
   describe '#find' do
     it 'returns the registered schedule by integer id' do
-      scheduler.schedule('* * * * *') {}
-      scheduler.schedule('5 0 * * *') {}
+      scheduler.schedule('First', '* * * * *') {}
+      scheduler.schedule('Second', '5 0 * * *') {}
 
-      expect(scheduler.find(0).cron_expr).to eq('* * * * *')
-      expect(scheduler.find(1).cron_expr).to eq('5 0 * * *')
+      expect(scheduler.find(0).name).to eq('First')
+      expect(scheduler.find(1).name).to eq('Second')
     end
 
     it 'returns nil for an unknown id' do
@@ -76,13 +90,13 @@ RSpec.describe Sidereal::Scheduler do
 
   describe '#tick' do
     it 'fires nothing on the first tick (window is empty)' do
-      scheduler.schedule('* * * * *') {}
+      scheduler.schedule('Every minute', '* * * * *') {}
       scheduler.tick
       expect(store.appended).to be_empty
     end
 
-    it 'dispatches a TriggerSchedule when a schedule fires inside (last_tick_at, now]' do
-      scheduler.schedule('* * * * *') {}
+    it 'dispatches a TriggerSchedule with schedule_id, schedule_name and producer_label metadata' do
+      scheduler.schedule('Every minute', '* * * * *') {}
       scheduler.tick           # baseline
       advance(60)
       scheduler.tick
@@ -91,22 +105,24 @@ RSpec.describe Sidereal::Scheduler do
       msg = store.appended.first
       expect(msg).to be_a(Sidereal::System::TriggerSchedule)
       expect(msg.payload.schedule_id).to eq(0)
-      expect(msg.metadata[:producer]).to eq('Schedule #0 (* * * * *)')
+      expect(msg.payload.schedule_name).to eq('Every minute')
+      expect(msg.metadata[:producer]).to eq("Schedule #0 'Every minute' (* * * * *)")
     end
 
     it 'dispatches one TriggerSchedule per due schedule, even when crons overlap' do
-      scheduler.schedule('* * * * *') {}
-      scheduler.schedule('* * * * *') {}
+      scheduler.schedule('A', '* * * * *') {}
+      scheduler.schedule('B', '* * * * *') {}
       scheduler.tick
       advance(60)
       scheduler.tick
 
       expect(store.appended.size).to eq(2)
       expect(store.appended.map { |m| m.payload.schedule_id }).to contain_exactly(0, 1)
+      expect(store.appended.map { |m| m.payload.schedule_name }).to contain_exactly('A', 'B')
     end
 
     it 'fires each schedule at most once per tick (no catch-up — matches crond)' do
-      scheduler.schedule('* * * * *') {}
+      scheduler.schedule('Every minute', '* * * * *') {}
       scheduler.tick
       advance(5 * 60 + 30)
       scheduler.tick
@@ -122,8 +138,8 @@ RSpec.describe Sidereal::Scheduler do
         end
       end.new
       sched = described_class.new(clock: clock, store: flaky)
-      sched.schedule('* * * * *') {}
-      sched.schedule('* * * * *') {}
+      sched.schedule('A', '* * * * *') {}
+      sched.schedule('B', '* * * * *') {}
 
       sched.tick
       advance(60)
@@ -135,7 +151,7 @@ RSpec.describe Sidereal::Scheduler do
     end
 
     it 'does not mutate registered Schedules across ticks' do
-      scheduler.schedule('* * * * *') {}
+      scheduler.schedule('Every minute', '* * * * *') {}
       original = scheduler.schedules.first
       scheduler.tick
       advance(120)
@@ -155,21 +171,21 @@ RSpec.describe Sidereal::Scheduler do
     let(:fake_cmd) { Object.new }
 
     it 'instance_execs the block on the given context' do
-      scheduler.schedule('* * * * *') { record(:fired) }
+      scheduler.schedule('Tick', '* * * * *') { record(:fired) }
       scheduler.find(0).run_in(recorder, fake_cmd)
 
       expect(recorder.seen).to eq([:fired])
     end
 
     it 'yields the triggering cmd to the block' do
-      scheduler.schedule('* * * * *') { |cmd| record(cmd) }
+      scheduler.schedule('Tick', '* * * * *') { |cmd| record(cmd) }
       scheduler.find(0).run_in(recorder, fake_cmd)
 
       expect(recorder.seen).to eq([fake_cmd])
     end
 
     it 'tolerates blocks that do not declare a cmd parameter (proc semantics)' do
-      scheduler.schedule('* * * * *') { record(:no_arg_block) }
+      scheduler.schedule('Tick', '* * * * *') { record(:no_arg_block) }
       expect { scheduler.find(0).run_in(recorder, fake_cmd) }.not_to raise_error
       expect(recorder.seen).to eq([:no_arg_block])
     end
@@ -178,7 +194,7 @@ RSpec.describe Sidereal::Scheduler do
   describe 'fiber lifecycle' do
     it 'fires at least once when started under a real Async task with a fast tick interval' do
       sched = described_class.new(tick_interval: 0.05, store: store)
-      sched.schedule('* * * * * *') {}
+      sched.schedule('Every second', '* * * * * *') {}
 
       Sync do |task|
         sched.start(task)
@@ -207,7 +223,7 @@ RSpec.describe Sidereal::Scheduler do
 
     it 'does not tick while the elector reports follower' do
       sched = described_class.new(tick_interval: 0.02, store: store, elector: elector)
-      sched.schedule('* * * * * *') {}
+      sched.schedule('Every second', '* * * * * *') {}
 
       Sync do |task|
         sched.start(task)
@@ -220,7 +236,7 @@ RSpec.describe Sidereal::Scheduler do
 
     it 'starts ticking on promotion and stops on demotion' do
       sched = described_class.new(tick_interval: 0.02, store: store, elector: elector)
-      sched.schedule('* * * * * *') {}
+      sched.schedule('Every second', '* * * * * *') {}
 
       Sync do |task|
         sched.start(task)

--- a/spec/scheduler_spec.rb
+++ b/spec/scheduler_spec.rb
@@ -8,8 +8,6 @@ SchedTick = Sidereal::Message.define('test.sched_tick') do
   attribute :n, Sidereal::Types::Integer
 end
 
-SchedNoPayload = Sidereal::Message.define('test.sched_no_payload')
-
 # -- Fake store: records appends without async machinery --
 
 class RecordingStore
@@ -22,6 +20,18 @@ class RecordingStore
   def append(msg)
     @appended << msg
     true
+  end
+end
+
+class FakePubSub
+  attr_reader :published
+
+  def initialize
+    @published = []
+  end
+
+  def publish(channel, message)
+    @published << { channel: channel, message: message }
   end
 end
 
@@ -41,12 +51,26 @@ RSpec.describe Sidereal::Scheduler do
   subject(:scheduler) { described_class.new(clock: clock, store: store) }
 
   describe '#schedule' do
-    it 'parses the cron and adds an immutable Schedule' do
+    it 'parses the cron and adds an immutable Schedule with a monotonic integer id' do
       scheduler.schedule('* * * * *') {}
-      expect(scheduler.schedules.size).to eq(1)
-      sch = scheduler.schedules.first
-      expect(sch).to be_frozen
-      expect(sch.cron_expr).to eq('* * * * *')
+      scheduler.schedule('5 0 * * *') {}
+      scheduler.schedule('*/10 * * * *') {}
+
+      ids = scheduler.schedules.map(&:id)
+      expect(ids).to eq([0, 1, 2])
+
+      first = scheduler.schedules.first
+      expect(first).to be_frozen
+      expect(first.cron_expr).to eq('* * * * *')
+    end
+
+    it 'allows multiple schedules sharing the same cron expression' do
+      scheduler.schedule('5 0 * * *') {}
+      scheduler.schedule('5 0 * * *') {}
+
+      expect(scheduler.schedules.size).to eq(2)
+      expect(scheduler.schedules.map(&:id)).to eq([0, 1])
+      expect(scheduler.schedules.map(&:cron_expr)).to eq(['5 0 * * *', '5 0 * * *'])
     end
 
     it 'raises ArgumentError on a malformed cron expression' do
@@ -54,42 +78,82 @@ RSpec.describe Sidereal::Scheduler do
     end
   end
 
+  describe '#find' do
+    it 'returns the registered schedule by integer id' do
+      scheduler.schedule('* * * * *') {}
+      scheduler.schedule('5 0 * * *') {}
+
+      expect(scheduler.find(0).cron_expr).to eq('* * * * *')
+      expect(scheduler.find(1).cron_expr).to eq('5 0 * * *')
+    end
+
+    it 'returns nil for an unknown id' do
+      expect(scheduler.find(99)).to be_nil
+    end
+  end
+
   describe '#tick' do
     it 'fires nothing on the first tick (window is empty)' do
-      scheduler.schedule('* * * * *') { dispatch SchedTick, n: 1 }
+      scheduler.schedule('* * * * *') {}
       scheduler.tick
       expect(store.appended).to be_empty
     end
 
-    it 'fires a schedule whose next firing falls inside (last_tick_at, now]' do
-      scheduler.schedule('* * * * *') { dispatch SchedTick, n: 1 }
-      scheduler.tick           # baseline = t0; nothing fires
-      advance(60)              # cross one minute boundary
+    it 'dispatches a TriggerSchedule when a schedule fires inside (last_tick_at, now]' do
+      scheduler.schedule('* * * * *') {}
+      scheduler.tick           # baseline
+      advance(60)
       scheduler.tick
+
       expect(store.appended.size).to eq(1)
-      expect(store.appended.first.payload.n).to eq(1)
+      msg = store.appended.first
+      expect(msg).to be_a(Sidereal::System::TriggerSchedule)
+      expect(msg.payload.schedule_id).to eq(0)
+      expect(msg.metadata[:producer]).to eq('* * * * *')
     end
 
-    it 'fires each schedule at most once per tick (no catch-up — matches crond)' do
-      scheduler.schedule('* * * * *') { dispatch SchedTick, n: 1 }
-      scheduler.tick           # baseline tick
-      advance(5 * 60 + 30)     # jump 5.5 minutes — 5 boundaries crossed
-      scheduler.tick
-      expect(store.appended.size).to eq(1)
-    end
-
-    it 'continues running when a scheduled block raises' do
-      scheduler.schedule('* * * * *') { raise 'boom' }
-      scheduler.schedule('* * * * *') { dispatch SchedTick, n: 99 }
+    it 'dispatches one TriggerSchedule per due schedule, even when crons overlap' do
+      scheduler.schedule('* * * * *') {}
+      scheduler.schedule('* * * * *') {}
       scheduler.tick
       advance(60)
       scheduler.tick
+
+      expect(store.appended.size).to eq(2)
+      expect(store.appended.map { |m| m.payload.schedule_id }).to contain_exactly(0, 1)
+    end
+
+    it 'fires each schedule at most once per tick (no catch-up — matches crond)' do
+      scheduler.schedule('* * * * *') {}
+      scheduler.tick
+      advance(5 * 60 + 30)
+      scheduler.tick
+
       expect(store.appended.size).to eq(1)
-      expect(store.appended.first.payload.n).to eq(99)
+    end
+
+    it 'continues running when a store append raises for one schedule' do
+      flaky = Class.new(RecordingStore) do
+        def append(msg)
+          raise 'first one fails' if @appended.empty? && msg.payload.schedule_id.zero?
+          super
+        end
+      end.new
+      sched = described_class.new(clock: clock, store: flaky)
+      sched.schedule('* * * * *') {}
+      sched.schedule('* * * * *') {}
+
+      sched.tick
+      advance(60)
+      sched.tick
+
+      # Second schedule still gets its TriggerSchedule even though the first raised.
+      expect(flaky.appended.size).to eq(1)
+      expect(flaky.appended.first.payload.schedule_id).to eq(1)
     end
 
     it 'does not mutate registered Schedules across ticks' do
-      scheduler.schedule('* * * * *') { dispatch SchedTick, n: 1 }
+      scheduler.schedule('* * * * *') {}
       original = scheduler.schedules.first
       scheduler.tick
       advance(120)
@@ -98,99 +162,17 @@ RSpec.describe Sidereal::Scheduler do
     end
   end
 
-  describe 'Run#dispatch' do
-    it 'stamps metadata[:producer] with the cron expression on Class+Hash form' do
-      scheduler.schedule('5 0 * * *') { dispatch SchedTick, n: 7 }
-      scheduler.tick
-      advance(24 * 3600)
-      scheduler.tick
+  describe 'Schedule#run_in' do
+    it 'instance_execs the block on the given context' do
+      recorder = Class.new do
+        attr_reader :seen
+        def record(value); (@seen ||= []) << value; end
+      end.new
 
-      msg = store.appended.last
-      expect(msg).to be_a(SchedTick)
-      expect(msg.payload.n).to eq(7)
-      expect(msg.metadata[:producer]).to eq('5 0 * * *')
-    end
+      scheduler.schedule('* * * * *') { record(:fired) }
+      scheduler.find(0).run_in(recorder)
 
-    it 'supports the bare Class form (no payload)' do
-      scheduler.schedule('* * * * *') { dispatch SchedNoPayload }
-      scheduler.tick
-      advance(60)
-      scheduler.tick
-
-      msg = store.appended.last
-      expect(msg).to be_a(SchedNoPayload)
-      expect(msg.metadata[:producer]).to eq('* * * * *')
-    end
-
-    it 'merges :producer into a pre-built Message instance' do
-      scheduler.schedule('* * * * *') do
-        msg = SchedTick.new(payload: { n: 42 }, metadata: { extra: 'x' })
-        dispatch msg
-      end
-      scheduler.tick
-      advance(60)
-      scheduler.tick
-
-      msg = store.appended.last
-      expect(msg.payload.n).to eq(42)
-      expect(msg.metadata[:producer]).to eq('* * * * *')
-      expect(msg.metadata[:extra]).to eq('x')
-    end
-
-    # Validation paths — Run#dispatch must refuse to enqueue invalid commands.
-    # The raise is caught by Scheduler#fire (logged), so the schedule itself
-    # keeps running but nothing reaches the store.
-    it 'raises Plumb::ParseError when Class+Hash form has an invalid payload' do
-      raised = nil
-      scheduler.schedule('* * * * *') do
-        begin
-          dispatch SchedTick, n: 'not_an_integer'
-        rescue Plumb::ParseError => ex
-          raised = ex
-        end
-      end
-      scheduler.tick
-      advance(60)
-      scheduler.tick
-
-      expect(raised).to be_a(Plumb::ParseError)
-      expect(raised.message).to include('Integer')
-      expect(store.appended).to be_empty
-    end
-
-    it 'raises Plumb::ParseError when bare Class form omits required payload attrs' do
-      raised = nil
-      scheduler.schedule('* * * * *') do
-        begin
-          dispatch SchedTick   # no :n provided, payload defaults to {}
-        rescue Plumb::ParseError => ex
-          raised = ex
-        end
-      end
-      scheduler.tick
-      advance(60)
-      scheduler.tick
-
-      expect(raised).to be_a(Plumb::ParseError)
-      expect(store.appended).to be_empty
-    end
-
-    it 'raises Plumb::ParseError when given a pre-built invalid Message' do
-      raised = nil
-      scheduler.schedule('* * * * *') do
-        begin
-          bad = SchedTick.new(payload: {})   # invalid: missing :n
-          dispatch bad
-        rescue Plumb::ParseError => ex
-          raised = ex
-        end
-      end
-      scheduler.tick
-      advance(60)
-      scheduler.tick
-
-      expect(raised).to be_a(Plumb::ParseError)
-      expect(store.appended).to be_empty
+      expect(recorder.seen).to eq([:fired])
     end
   end
 
@@ -201,19 +183,51 @@ RSpec.describe Sidereal::Scheduler do
     it 'registers on Sidereal.scheduler when called via App.schedule' do
       Class.new(Sidereal::App) do
         schedule '*/5 * * * *' do
-          dispatch SchedTick, n: 0
         end
       end
       expect(Sidereal.scheduler.schedules.size).to eq(1)
       expect(Sidereal.scheduler.schedules.first.cron_expr).to eq('*/5 * * * *')
     end
+
+    it 'TriggerSchedule handler runs the schedule block in the Commander instance' do
+      app_class = Class.new(Sidereal::App) do
+        command SchedTick do |_cmd|
+          # registered so dispatch routes SchedTick to commands, not events
+        end
+        schedule '*/5 * * * *' do
+          dispatch SchedTick, n: 42
+        end
+      end
+
+      sch = Sidereal.scheduler.schedules.first
+      trigger = Sidereal::System::TriggerSchedule.new(payload: { schedule_id: sch.id })
+      result = app_class.commander.handle(trigger, pubsub: FakePubSub.new)
+
+      expect(result.commands.size).to eq(1)
+      dispatched = result.commands.first
+      expect(dispatched).to be_a(SchedTick)
+      expect(dispatched.payload.n).to eq(42)
+      # Causation chain: the dispatched command points back at the TriggerSchedule.
+      expect(dispatched.causation_id).to eq(trigger.id)
+      expect(dispatched.correlation_id).to eq(trigger.correlation_id)
+    end
+
+    it 'TriggerSchedule handler is a no-op when the schedule_id is unknown (e.g. removed)' do
+      app_class = Class.new(Sidereal::App) do
+        # No schedule registered.
+      end
+
+      trigger = Sidereal::System::TriggerSchedule.new(payload: { schedule_id: 999 })
+      expect {
+        app_class.commander.handle(trigger, pubsub: FakePubSub.new)
+      }.not_to raise_error
+    end
   end
 
   describe 'fiber lifecycle' do
     it 'fires at least once when started under a real Async task with a fast tick interval' do
-      fired = []
       sched = described_class.new(tick_interval: 0.05, store: store)
-      sched.schedule('* * * * * *') { fired << Time.now }
+      sched.schedule('* * * * * *') {}
 
       Sync do |task|
         sched.start(task)
@@ -222,14 +236,12 @@ RSpec.describe Sidereal::Scheduler do
         task.stop
       end
 
-      expect(fired.size).to be >= 1
+      expect(store.appended.size).to be >= 1
+      expect(store.appended.first).to be_a(Sidereal::System::TriggerSchedule)
     end
   end
 
   describe 'elector integration' do
-    # Test elector that exposes promote!/demote! for direct manipulation.
-    # Mirrors the helper in spec/elector_spec.rb but redefined here so
-    # the file stays self-contained.
     let(:test_elector_class) do
       Class.new do
         include Sidereal::Elector::Callbacks
@@ -244,11 +256,11 @@ RSpec.describe Sidereal::Scheduler do
 
     it 'does not tick while the elector reports follower' do
       sched = described_class.new(tick_interval: 0.02, store: store, elector: elector)
-      sched.schedule('* * * * * *') { dispatch SchedTick, n: 1 }
+      sched.schedule('* * * * * *') {}
 
       Sync do |task|
         sched.start(task)
-        sleep 1.2     # would fire ~1× under AlwaysLeader, but we're follower
+        sleep 1.2
         task.stop
       end
 
@@ -257,7 +269,7 @@ RSpec.describe Sidereal::Scheduler do
 
     it 'starts ticking on promotion and stops on demotion' do
       sched = described_class.new(tick_interval: 0.02, store: store, elector: elector)
-      sched.schedule('* * * * * *') { dispatch SchedTick, n: 1 }
+      sched.schedule('* * * * * *') {}
 
       Sync do |task|
         sched.start(task)
@@ -265,12 +277,12 @@ RSpec.describe Sidereal::Scheduler do
         expect(store.appended).to be_empty   # not leader yet
 
         elector.promote!
-        sleep 1.2                             # leader now: ~1 fire expected
+        sleep 1.2
         expect(store.appended.size).to be >= 1
 
         elector.demote!
         before = store.appended.size
-        sleep 1.2                             # demoted: no further fires
+        sleep 1.2
         expect(store.appended.size).to eq(before)
 
         task.stop

--- a/spec/scheduler_spec.rb
+++ b/spec/scheduler_spec.rb
@@ -2,12 +2,6 @@
 
 require 'spec_helper'
 
-# -- Test messages --
-
-SchedTick = Sidereal::Message.define('test.sched_tick') do
-  attribute :n, Sidereal::Types::Integer
-end
-
 # -- Fake store: records appends without async machinery --
 
 class RecordingStore
@@ -20,18 +14,6 @@ class RecordingStore
   def append(msg)
     @appended << msg
     true
-  end
-end
-
-class FakePubSub
-  attr_reader :published
-
-  def initialize
-    @published = []
-  end
-
-  def publish(channel, message)
-    @published << { channel: channel, message: message }
   end
 end
 
@@ -190,58 +172,6 @@ RSpec.describe Sidereal::Scheduler do
       scheduler.schedule('* * * * *') { record(:no_arg_block) }
       expect { scheduler.find(0).run_in(recorder, fake_cmd) }.not_to raise_error
       expect(recorder.seen).to eq([:no_arg_block])
-    end
-  end
-
-  describe 'integration with App.schedule' do
-    before { Sidereal.reset_scheduler! }
-    after { Sidereal.reset_scheduler! }
-
-    it 'registers on Sidereal.scheduler when called via App.schedule' do
-      Class.new(Sidereal::App) do
-        schedule '*/5 * * * *' do
-        end
-      end
-      expect(Sidereal.scheduler.schedules.size).to eq(1)
-      expect(Sidereal.scheduler.schedules.first.cron_expr).to eq('*/5 * * * *')
-    end
-
-    it 'TriggerSchedule handler runs the schedule block in the Commander instance and yields the cmd' do
-      app_class = Class.new(Sidereal::App) do
-        command SchedTick do |_cmd|
-          # registered so dispatch routes SchedTick to commands, not events
-        end
-        schedule '*/5 * * * *' do |cmd|
-          # Read the producer from the cmd's metadata to prove the cmd is yielded.
-          dispatch SchedTick, n: cmd.metadata[:producer].length
-        end
-      end
-
-      sch = Sidereal.scheduler.schedules.first
-      trigger = Sidereal::System::TriggerSchedule.new(
-        payload: { schedule_id: sch.id },
-        metadata: { producer: sch.name }
-      )
-      result = app_class.commander.handle(trigger, pubsub: FakePubSub.new)
-
-      expect(result.commands.size).to eq(1)
-      dispatched = result.commands.first
-      expect(dispatched).to be_a(SchedTick)
-      expect(dispatched.payload.n).to eq(sch.name.length)
-      # Causation chain: the dispatched command points back at the TriggerSchedule.
-      expect(dispatched.causation_id).to eq(trigger.id)
-      expect(dispatched.correlation_id).to eq(trigger.correlation_id)
-    end
-
-    it 'TriggerSchedule handler is a no-op when the schedule_id is unknown (e.g. removed)' do
-      app_class = Class.new(Sidereal::App) do
-        # No schedule registered.
-      end
-
-      trigger = Sidereal::System::TriggerSchedule.new(payload: { schedule_id: 999 })
-      expect {
-        app_class.commander.handle(trigger, pubsub: FakePubSub.new)
-      }.not_to raise_error
     end
   end
 

--- a/spec/scheduler_spec.rb
+++ b/spec/scheduler_spec.rb
@@ -1,0 +1,228 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# -- Test messages --
+
+SchedTick = Sidereal::Message.define('test.sched_tick') do
+  attribute :n, Sidereal::Types::Integer
+end
+
+SchedNoPayload = Sidereal::Message.define('test.sched_no_payload')
+
+# -- Fake store: records appends without async machinery --
+
+class RecordingStore
+  attr_reader :appended
+
+  def initialize
+    @appended = []
+  end
+
+  def append(msg)
+    @appended << msg
+    true
+  end
+end
+
+RSpec.describe Sidereal::Scheduler do
+  let(:store) { RecordingStore.new }
+
+  # Anchored on a Monday at 12:00:00 so cron math is predictable across
+  # day-of-week and minute boundaries.
+  let(:t0) { Time.local(2026, 5, 4, 12, 0, 0) }
+  let(:clock_holder) { [t0] }
+  let(:clock) { -> { clock_holder.first } }
+
+  def advance(seconds)
+    clock_holder[0] = clock_holder.first + seconds
+  end
+
+  subject(:scheduler) { described_class.new(clock: clock, store: store) }
+
+  describe '#schedule' do
+    it 'parses the cron and adds an immutable Schedule' do
+      scheduler.schedule('* * * * *') {}
+      expect(scheduler.schedules.size).to eq(1)
+      sch = scheduler.schedules.first
+      expect(sch).to be_frozen
+      expect(sch.cron_expr).to eq('* * * * *')
+    end
+
+    it 'raises ArgumentError on a malformed cron expression' do
+      expect { scheduler.schedule('not a cron') {} }.to raise_error(ArgumentError, /invalid cron/)
+    end
+  end
+
+  describe '#tick' do
+    it 'fires nothing on the first tick (window is empty)' do
+      scheduler.schedule('* * * * *') { dispatch SchedTick, n: 1 }
+      scheduler.tick
+      expect(store.appended).to be_empty
+    end
+
+    it 'fires a schedule whose next firing falls inside (last_tick_at, now]' do
+      scheduler.schedule('* * * * *') { dispatch SchedTick, n: 1 }
+      scheduler.tick           # baseline = t0; nothing fires
+      advance(60)              # cross one minute boundary
+      scheduler.tick
+      expect(store.appended.size).to eq(1)
+      expect(store.appended.first.payload.n).to eq(1)
+    end
+
+    it 'fires each schedule at most once per tick (no catch-up — matches crond)' do
+      scheduler.schedule('* * * * *') { dispatch SchedTick, n: 1 }
+      scheduler.tick           # baseline tick
+      advance(5 * 60 + 30)     # jump 5.5 minutes — 5 boundaries crossed
+      scheduler.tick
+      expect(store.appended.size).to eq(1)
+    end
+
+    it 'continues running when a scheduled block raises' do
+      scheduler.schedule('* * * * *') { raise 'boom' }
+      scheduler.schedule('* * * * *') { dispatch SchedTick, n: 99 }
+      scheduler.tick
+      advance(60)
+      scheduler.tick
+      expect(store.appended.size).to eq(1)
+      expect(store.appended.first.payload.n).to eq(99)
+    end
+
+    it 'does not mutate registered Schedules across ticks' do
+      scheduler.schedule('* * * * *') { dispatch SchedTick, n: 1 }
+      original = scheduler.schedules.first
+      scheduler.tick
+      advance(120)
+      scheduler.tick
+      expect(scheduler.schedules.first).to eq(original)
+    end
+  end
+
+  describe 'Run#dispatch' do
+    it 'stamps metadata[:producer] with the cron expression on Class+Hash form' do
+      scheduler.schedule('5 0 * * *') { dispatch SchedTick, n: 7 }
+      scheduler.tick
+      advance(24 * 3600)
+      scheduler.tick
+
+      msg = store.appended.last
+      expect(msg).to be_a(SchedTick)
+      expect(msg.payload.n).to eq(7)
+      expect(msg.metadata[:producer]).to eq('5 0 * * *')
+    end
+
+    it 'supports the bare Class form (no payload)' do
+      scheduler.schedule('* * * * *') { dispatch SchedNoPayload }
+      scheduler.tick
+      advance(60)
+      scheduler.tick
+
+      msg = store.appended.last
+      expect(msg).to be_a(SchedNoPayload)
+      expect(msg.metadata[:producer]).to eq('* * * * *')
+    end
+
+    it 'merges :producer into a pre-built Message instance' do
+      scheduler.schedule('* * * * *') do
+        msg = SchedTick.new(payload: { n: 42 }, metadata: { extra: 'x' })
+        dispatch msg
+      end
+      scheduler.tick
+      advance(60)
+      scheduler.tick
+
+      msg = store.appended.last
+      expect(msg.payload.n).to eq(42)
+      expect(msg.metadata[:producer]).to eq('* * * * *')
+      expect(msg.metadata[:extra]).to eq('x')
+    end
+
+    # Validation paths — Run#dispatch must refuse to enqueue invalid commands.
+    # The raise is caught by Scheduler#fire (logged), so the schedule itself
+    # keeps running but nothing reaches the store.
+    it 'raises Plumb::ParseError when Class+Hash form has an invalid payload' do
+      raised = nil
+      scheduler.schedule('* * * * *') do
+        begin
+          dispatch SchedTick, n: 'not_an_integer'
+        rescue Plumb::ParseError => ex
+          raised = ex
+        end
+      end
+      scheduler.tick
+      advance(60)
+      scheduler.tick
+
+      expect(raised).to be_a(Plumb::ParseError)
+      expect(raised.message).to include('Integer')
+      expect(store.appended).to be_empty
+    end
+
+    it 'raises Plumb::ParseError when bare Class form omits required payload attrs' do
+      raised = nil
+      scheduler.schedule('* * * * *') do
+        begin
+          dispatch SchedTick   # no :n provided, payload defaults to {}
+        rescue Plumb::ParseError => ex
+          raised = ex
+        end
+      end
+      scheduler.tick
+      advance(60)
+      scheduler.tick
+
+      expect(raised).to be_a(Plumb::ParseError)
+      expect(store.appended).to be_empty
+    end
+
+    it 'raises Plumb::ParseError when given a pre-built invalid Message' do
+      raised = nil
+      scheduler.schedule('* * * * *') do
+        begin
+          bad = SchedTick.new(payload: {})   # invalid: missing :n
+          dispatch bad
+        rescue Plumb::ParseError => ex
+          raised = ex
+        end
+      end
+      scheduler.tick
+      advance(60)
+      scheduler.tick
+
+      expect(raised).to be_a(Plumb::ParseError)
+      expect(store.appended).to be_empty
+    end
+  end
+
+  describe 'integration with App.schedule' do
+    before { Sidereal.reset_scheduler! }
+    after { Sidereal.reset_scheduler! }
+
+    it 'registers on Sidereal.scheduler when called via App.schedule' do
+      Class.new(Sidereal::App) do
+        schedule '*/5 * * * *' do
+          dispatch SchedTick, n: 0
+        end
+      end
+      expect(Sidereal.scheduler.schedules.size).to eq(1)
+      expect(Sidereal.scheduler.schedules.first.cron_expr).to eq('*/5 * * * *')
+    end
+  end
+
+  describe 'fiber lifecycle' do
+    it 'fires at least once when started under a real Async task with a fast tick interval' do
+      fired = []
+      sched = described_class.new(tick_interval: 0.05, store: store)
+      sched.schedule('* * * * * *') { fired << Time.now }
+
+      Sync do |task|
+        sched.start(task)
+        # The very-second cron + 50ms tick should fire within ~1.1s.
+        sleep 1.2
+        task.stop
+      end
+
+      expect(fired.size).to be >= 1
+    end
+  end
+end

--- a/spec/scheduler_spec.rb
+++ b/spec/scheduler_spec.rb
@@ -74,6 +74,70 @@ RSpec.describe Sidereal::Scheduler do
     end
   end
 
+  describe '#schedule with from:/to:' do
+    let(:from_t) { Time.local(2026, 6, 1, 0, 0, 0) }
+    let(:to_t)   { Time.local(2026, 6, 1, 23, 59, 59) }
+
+    it 'accepts Time objects unchanged' do
+      scheduler.schedule('Daily', '5 0 * * *', from: from_t, to: to_t) {}
+      sch = scheduler.schedules.first
+      expect(sch.from).to eq(from_t)
+      expect(sch.to).to eq(to_t)
+    end
+
+    it 'parses ISO8601 strings to Time' do
+      scheduler.schedule('Daily', '5 0 * * *',
+                         from: '2026-02-03T10:00:00Z',
+                         to: '2026-10-01T00:00:00Z') {}
+      sch = scheduler.schedules.first
+      expect(sch.from).to be_a(Time)
+      expect(sch.from).to eq(Time.utc(2026, 2, 3, 10, 0, 0))
+      expect(sch.to).to be_a(Time)
+      expect(sch.to).to eq(Time.utc(2026, 10, 1, 0, 0, 0))
+    end
+
+    it 'normalises DateTime via .to_time' do
+      require 'date'
+      dt = DateTime.new(2026, 6, 1, 12, 0, 0)
+      scheduler.schedule('Daily', '5 0 * * *', from: dt, to: dt + 30) {}
+      expect(scheduler.schedules.first.from).to be_a(Time)
+    end
+
+    it 'raises ArgumentError on a non-Time, non-String, non-DateTime input' do
+      expect {
+        scheduler.schedule('Bad', '5 0 * * *', from: 12345) {}
+      }.to raise_error(ArgumentError, /expected Time, DateTime, or ISO8601 String/)
+    end
+
+    it 'raises when both bounds are given and the cron never fires inside the window' do
+      # Daily at 00:05 with a 30-minute window starting at 12:00 — never fires.
+      expect {
+        scheduler.schedule('Daily', '5 0 * * *',
+                           from: Time.local(2026, 6, 1, 12, 0, 0),
+                           to:   Time.local(2026, 6, 1, 12, 30, 0)) {}
+      }.to raise_error(ArgumentError, /never fires inside the window/)
+    end
+
+    it 'accepts only from: without validation' do
+      expect {
+        scheduler.schedule('Hourly from now', '0 * * * *', from: Time.now) {}
+      }.not_to raise_error
+    end
+
+    it 'accepts only to: without validation' do
+      expect {
+        scheduler.schedule('Hourly until far future', '0 * * * *', to: Time.now + 86400) {}
+      }.not_to raise_error
+    end
+
+    it 'leaves from/to nil when not provided (existing schedules)' do
+      scheduler.schedule('Plain', '5 0 * * *') {}
+      sch = scheduler.schedules.first
+      expect(sch.from).to be_nil
+      expect(sch.to).to be_nil
+    end
+  end
+
   describe '#find' do
     it 'returns the registered schedule by integer id' do
       scheduler.schedule('First', '* * * * *') {}
@@ -157,6 +221,56 @@ RSpec.describe Sidereal::Scheduler do
       advance(120)
       scheduler.tick
       expect(scheduler.schedules.first).to eq(original)
+    end
+  end
+
+  describe '#tick with windowed schedules' do
+    it 'skips a schedule whose from: is still in the future' do
+      scheduler.schedule('Every minute', '* * * * *', from: t0 + 60) {}
+      scheduler.tick           # baseline at t0
+      advance(30)              # now = t0 + 30, before from
+      scheduler.tick
+
+      expect(store.appended).to be_empty
+    end
+
+    it 'fires once from: has passed and a cron boundary fell inside the active window' do
+      scheduler.schedule('Every minute', '* * * * *', from: t0 + 60) {}
+      scheduler.tick           # baseline at t0
+      advance(90)              # now = t0 + 90 — past from + crossed t0+60 minute boundary
+      scheduler.tick
+
+      expect(store.appended.size).to eq(1)
+    end
+
+    it 'fires before to:, skips after to:' do
+      scheduler.schedule('Every minute', '* * * * *', to: t0 + 90) {}
+      scheduler.tick           # baseline at t0
+      advance(60)              # now = t0 + 60 — before to:, boundary crossed
+      scheduler.tick
+      expect(store.appended.size).to eq(1)
+
+      advance(120)             # now = t0 + 180 — past to:
+      scheduler.tick
+      expect(store.appended.size).to eq(1)   # no new fire
+    end
+
+    it 'with both bounds, fires inside the window and skips outside' do
+      scheduler.schedule('Every minute', '* * * * *',
+                         from: t0 + 60, to: t0 + 180) {}
+
+      scheduler.tick           # baseline at t0
+      advance(30)              # before from
+      scheduler.tick
+      expect(store.appended.size).to eq(0)
+
+      advance(60)              # now = t0 + 90 — inside window, boundary at t0+60 crossed
+      scheduler.tick
+      expect(store.appended.size).to eq(1)
+
+      advance(180)             # now = t0 + 270 — past to:
+      scheduler.tick
+      expect(store.appended.size).to eq(1)   # no further fire
     end
   end
 

--- a/spec/scheduler_spec.rb
+++ b/spec/scheduler_spec.rb
@@ -225,4 +225,56 @@ RSpec.describe Sidereal::Scheduler do
       expect(fired.size).to be >= 1
     end
   end
+
+  describe 'elector integration' do
+    # Test elector that exposes promote!/demote! for direct manipulation.
+    # Mirrors the helper in spec/elector_spec.rb but redefined here so
+    # the file stays self-contained.
+    let(:test_elector_class) do
+      Class.new do
+        include Sidereal::Elector::Callbacks
+        def initialize = @leader = false
+        def leader? = @leader
+        def start(_task) = self
+        public :promote!, :demote!
+      end
+    end
+
+    let(:elector) { test_elector_class.new }
+
+    it 'does not tick while the elector reports follower' do
+      sched = described_class.new(tick_interval: 0.02, store: store, elector: elector)
+      sched.schedule('* * * * * *') { dispatch SchedTick, n: 1 }
+
+      Sync do |task|
+        sched.start(task)
+        sleep 1.2     # would fire ~1× under AlwaysLeader, but we're follower
+        task.stop
+      end
+
+      expect(store.appended).to be_empty
+    end
+
+    it 'starts ticking on promotion and stops on demotion' do
+      sched = described_class.new(tick_interval: 0.02, store: store, elector: elector)
+      sched.schedule('* * * * * *') { dispatch SchedTick, n: 1 }
+
+      Sync do |task|
+        sched.start(task)
+        sleep 0.1
+        expect(store.appended).to be_empty   # not leader yet
+
+        elector.promote!
+        sleep 1.2                             # leader now: ~1 fire expected
+        expect(store.appended.size).to be >= 1
+
+        elector.demote!
+        before = store.appended.size
+        sleep 1.2                             # demoted: no further fires
+        expect(store.appended.size).to eq(before)
+
+        task.stop
+      end
+    end
+  end
 end

--- a/spec/scheduler_spec.rb
+++ b/spec/scheduler_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe Sidereal::Scheduler do
       msg = store.appended.first
       expect(msg).to be_a(Sidereal::System::TriggerSchedule)
       expect(msg.payload.schedule_id).to eq(0)
-      expect(msg.metadata[:producer]).to eq('* * * * *')
+      expect(msg.metadata[:producer]).to eq('Schedule #0 (* * * * *)')
     end
 
     it 'dispatches one TriggerSchedule per due schedule, even when crons overlap' do

--- a/spec/scheduler_spec.rb
+++ b/spec/scheduler_spec.rb
@@ -2,8 +2,15 @@
 
 require 'spec_helper'
 
-# -- Fake store: records appends without async machinery --
+# Test message classes used by the dumb-Scheduler tests below.
+TestSchedRun = Sidereal::Message.define('test.sched_run') do
+  attribute :n, Sidereal::Types::Integer
+end
 
+TestSchedEnter = Sidereal::Message.define('test.sched_enter')
+TestSchedExit  = Sidereal::Message.define('test.sched_exit')
+
+# -- Fake store: records appends without async machinery --
 class RecordingStore
   attr_reader :appended
 
@@ -20,305 +27,361 @@ end
 RSpec.describe Sidereal::Scheduler do
   let(:store) { RecordingStore.new }
 
-  # Anchored on a Monday at 12:00:00 so cron math is predictable across
-  # day-of-week and minute boundaries.
   let(:t0) { Time.local(2026, 5, 4, 12, 0, 0) }
-  let(:clock_holder) { [t0] }
-  let(:clock) { -> { clock_holder.first } }
 
-  def advance(seconds)
-    clock_holder[0] = clock_holder.first + seconds
-  end
+  # Most tests pass an explicit time to +#tick+, so no clock mocking
+  # is needed. The fiber-lifecycle and elector tests at the bottom of
+  # the file still inject a clock since they exercise the
+  # tick-fiber's own scheduling.
+  subject(:scheduler) { described_class.new(store: store) }
 
-  subject(:scheduler) { described_class.new(clock: clock, store: store) }
+  describe '#schedule (builder API)' do
+    it 'is built incrementally and frozen by Scheduler#schedule' do
+      sch = nil
+      scheduler.schedule 'Hourly' do |sc|
+        sc.run_at '0 * * * *', TestSchedRun, n: 7
+        sch = sc
+      end
 
-  describe '#schedule' do
-    it 'parses the cron and adds an immutable Schedule with monotonic id and the supplied name' do
-      scheduler.schedule('Every minute', '* * * * *') {}
-      scheduler.schedule('Daily at 00:05', '5 0 * * *') {}
-      scheduler.schedule('Every 10 min', '*/10 * * * *') {}
-
-      expect(scheduler.schedules.map(&:id)).to eq([0, 1, 2])
-      expect(scheduler.schedules.map(&:name)).to eq(['Every minute', 'Daily at 00:05', 'Every 10 min'])
-
-      first = scheduler.schedules.first
-      expect(first).to be_frozen
-      expect(first.cron_expr).to eq('* * * * *')
-      expect(first.name).to eq('Every minute')
+      expect(sch).to be_frozen
+      expect(sch.name).to eq('Hourly')
+      expect(sch.expression).to eq('0 * * * *')
+      expect(sch.run.klass).to eq(TestSchedRun)
+      expect(sch.run.payload).to eq(n: 7)
     end
 
-    it 'allows multiple schedules sharing the same cron expression' do
-      scheduler.schedule('A', '5 0 * * *') {}
-      scheduler.schedule('B', '5 0 * * *') {}
+    it 'accepts a pre-built Schedule passed positionally' do
+      built = Sidereal::Scheduler::Schedule.new('X')
+      built.run_at '* * * * *', TestSchedRun, n: 1
 
-      expect(scheduler.schedules.size).to eq(2)
-      expect(scheduler.schedules.map(&:id)).to eq([0, 1])
-      expect(scheduler.schedules.map(&:name)).to eq(['A', 'B'])
-      expect(scheduler.schedules.map(&:cron_expr)).to eq(['5 0 * * *', '5 0 * * *'])
+      scheduler.schedule(built)
+      expect(scheduler.schedules.size).to eq(1)
+      expect(scheduler.schedules.first).to equal(built)
     end
 
-    it 'raises ArgumentError on a malformed cron expression' do
-      expect { scheduler.schedule('Bad', 'not a cron') {} }.to raise_error(ArgumentError, /invalid cron/)
+    it 'rejects nil/empty schedule names at construction' do
+      expect { Sidereal::Scheduler::Schedule.new(nil) }.to raise_error(ArgumentError, /name is required/)
+      expect { Sidereal::Scheduler::Schedule.new('')  }.to raise_error(ArgumentError, /name is required/)
     end
 
-    it 'auto-names the schedule when only a cron_expr is supplied' do
-      scheduler.schedule('5 0 * * *') {}
-      scheduler.schedule('* * * * *') {}
-
-      expect(scheduler.schedules.map(&:name)).to eq(['0 (5 0 * * *)', '1 (* * * * *)'])
-    end
-
-    it 'raises on bad arity' do
-      expect { scheduler.schedule {} }.to raise_error(ArgumentError, /schedule takes/)
-      expect { scheduler.schedule('a', 'b', 'c') {} }.to raise_error(ArgumentError, /schedule takes/)
-    end
-  end
-
-  describe '#schedule with from:/to:' do
-    let(:from_t) { Time.local(2026, 6, 1, 0, 0, 0) }
-    let(:to_t)   { Time.local(2026, 6, 1, 23, 59, 59) }
-
-    it 'accepts Time objects unchanged' do
-      scheduler.schedule('Daily', '5 0 * * *', from: from_t, to: to_t) {}
-      sch = scheduler.schedules.first
-      expect(sch.from).to eq(from_t)
-      expect(sch.to).to eq(to_t)
-    end
-
-    it 'parses ISO8601 strings to Time' do
-      scheduler.schedule('Daily', '5 0 * * *',
-                         from: '2026-02-03T10:00:00Z',
-                         to: '2026-10-01T00:00:00Z') {}
-      sch = scheduler.schedules.first
-      expect(sch.from).to be_a(Time)
-      expect(sch.from).to eq(Time.utc(2026, 2, 3, 10, 0, 0))
-      expect(sch.to).to be_a(Time)
-      expect(sch.to).to eq(Time.utc(2026, 10, 1, 0, 0, 0))
-    end
-
-    it 'normalises DateTime via .to_time' do
-      require 'date'
-      dt = DateTime.new(2026, 6, 1, 12, 0, 0)
-      scheduler.schedule('Daily', '5 0 * * *', from: dt, to: dt + 30) {}
-      expect(scheduler.schedules.first.from).to be_a(Time)
-    end
-
-    it 'raises ArgumentError on a non-Time, non-String, non-DateTime input' do
+    it 'raises when run_at is missing' do
       expect {
-        scheduler.schedule('Bad', '5 0 * * *', from: 12345) {}
-      }.to raise_error(ArgumentError, /expected Time, DateTime, or ISO8601 String/)
+        scheduler.schedule('NoRun') { |_sc| }
+      }.to raise_error(ArgumentError, /run_at is required/)
     end
 
-    it 'raises when both bounds are given and the cron never fires inside the window' do
-      # Daily at 00:05 with a 30-minute window starting at 12:00 — never fires.
+    it 'raises on a malformed expression' do
       expect {
-        scheduler.schedule('Daily', '5 0 * * *',
-                           from: Time.local(2026, 6, 1, 12, 0, 0),
-                           to:   Time.local(2026, 6, 1, 12, 30, 0)) {}
+        scheduler.schedule('Bad') do |sc|
+          sc.run_at 'not a cron', TestSchedRun, n: 1
+        end
+      }.to raise_error(ArgumentError, /invalid schedule expression/)
+    end
+
+    it 'requires a class on run_at' do
+      expect {
+        scheduler.schedule('Bare') { |sc| sc.run_at '* * * * *' }
+      }.to raise_error(ArgumentError, /run_at requires a command class/)
+    end
+
+    it 'coerces enter_at strings to Time' do
+      scheduler.schedule 'Strs' do |sc|
+        sc.run_at '* * * * *', TestSchedRun, n: 1
+        sc.enter_at '2026-06-01T00:00:00Z'
+      end
+      expect(scheduler.schedules.first.enter_at).to eq(Time.utc(2026, 6, 1))
+    end
+
+    it 'accepts a callable exit_at receiving the resolved enter_at' do
+      enter = Time.local(2026, 6, 1, 12)
+      scheduler.schedule 'Window' do |sc|
+        sc.run_at '* * * * *', TestSchedRun, n: 1
+        sc.enter_at enter
+        sc.exit_at ->(e) { e + 3600 }
+      end
+      expect(scheduler.schedules.first.exit_at).to eq(enter + 3600)
+    end
+
+    it 'raises with a guidance-rich message when exit_at is callable without an enter_at' do
+      expect {
+        scheduler.schedule 'BadExit' do |sc|
+          sc.run_at '* * * * *', TestSchedRun, n: 1
+          sc.exit_at ->(e) { e + 60 }
+        end
+      }.to raise_error(ArgumentError) { |err|
+        expect(err.message).to include('"BadExit"')
+        expect(err.message).to include('exit_at was given a callable but no enter_at is set')
+        expect(err.message).to include('declare enter_at')
+        expect(err.message).to include('static Time/String/DateTime')
+      }
+    end
+
+    it 'accepts a Fugit duration string for exit_at, resolved relative to enter_at' do
+      enter = Time.utc(2026, 1, 1, 12, 0, 0)
+      scheduler.schedule 'PromoYear' do |sc|
+        sc.run_at '0 0 * * *', TestSchedRun, n: 1
+        sc.enter_at enter
+        sc.exit_at '12y12M', TestSchedExit
+      end
+
+      sch = scheduler.schedules.first
+      expect(sch.exit_at).to be_a(Time)
+      expect(sch.exit_at.year).to eq(2039)
+      expect(sch.exit_at.month).to eq(1)
+      expect(sch.exit.klass).to eq(TestSchedExit)
+    end
+
+    it 'accepts shorter duration strings (e.g. 1h30m) and ISO8601 (P1H30M-style) forms' do
+      enter = Time.utc(2026, 1, 1, 12)
+      scheduler.schedule 'Hourly' do |sc|
+        sc.run_at '* * * * *', TestSchedRun, n: 1
+        sc.enter_at enter
+        sc.exit_at '1h30m'
+      end
+
+      expect(scheduler.schedules.first.exit_at).to eq(enter + 90 * 60)
+    end
+
+    it 'raises with a duration-specific message when exit_at is a duration without an enter_at' do
+      expect {
+        scheduler.schedule 'NoEnter' do |sc|
+          sc.run_at '* * * * *', TestSchedRun, n: 1
+          sc.exit_at '1h30m'
+        end
+      }.to raise_error(ArgumentError) { |err|
+        expect(err.message).to include('"NoEnter"')
+        expect(err.message).to include('exit_at was given a duration but no enter_at is set')
+        expect(err.message).to include('Durations are resolved relative to enter_at')
+        expect(err.message).to include('declare enter_at')
+        expect(err.message).to include('static Time/String/DateTime')
+      }
+    end
+
+    it 'allows a static exit_at without an enter_at' do
+      scheduler.schedule 'BoundedAbove' do |sc|
+        sc.run_at '* * * * *', TestSchedRun, n: 1
+        sc.exit_at '2026-12-31T00:00:00Z'
+      end
+
+      sch = scheduler.schedules.first
+      expect(sch.enter_at).to be_nil
+      expect(sch.exit_at).to eq(Time.utc(2026, 12, 31))
+    end
+
+    it 'raises when both bounds are present and the cron never fires inside the window' do
+      expect {
+        scheduler.schedule 'TooTight' do |sc|
+          sc.run_at '5 0 * * *', TestSchedRun, n: 1
+          sc.enter_at Time.local(2026, 6, 1, 12)
+          sc.exit_at  Time.local(2026, 6, 1, 12, 30)
+        end
       }.to raise_error(ArgumentError, /never fires inside the window/)
     end
 
-    it 'accepts only from: without validation' do
-      expect {
-        scheduler.schedule('Hourly from now', '0 * * * *', from: Time.now) {}
-      }.not_to raise_error
-    end
-
-    it 'accepts only to: without validation' do
-      expect {
-        scheduler.schedule('Hourly until far future', '0 * * * *', to: Time.now + 86400) {}
-      }.not_to raise_error
-    end
-
-    it 'leaves from/to nil when not provided (existing schedules)' do
-      scheduler.schedule('Plain', '5 0 * * *') {}
-      sch = scheduler.schedules.first
-      expect(sch.from).to be_nil
-      expect(sch.to).to be_nil
+    it 'rejects non-String, non-Schedule first argument' do
+      expect { scheduler.schedule(42) }.to raise_error(ArgumentError, /expected Schedule or String name/)
     end
   end
 
-  describe '#find' do
-    it 'returns the registered schedule by integer id' do
-      scheduler.schedule('First', '* * * * *') {}
-      scheduler.schedule('Second', '5 0 * * *') {}
-
-      expect(scheduler.find(0).name).to eq('First')
-      expect(scheduler.find(1).name).to eq('Second')
+  describe '#tick — run dispatch' do
+    def schedule_run(scheduler, name: 'My sched', n: 1, exp: '* * * * *')
+      scheduler.schedule name do |sc|
+        sc.run_at exp, TestSchedRun, n: n
+      end
     end
 
-    it 'returns nil for an unknown id' do
-      expect(scheduler.find(99)).to be_nil
-    end
-  end
-
-  describe '#tick' do
     it 'fires nothing on the first tick (window is empty)' do
-      scheduler.schedule('Every minute', '* * * * *') {}
-      scheduler.tick
+      schedule_run(scheduler)
+      scheduler.tick(t0)
       expect(store.appended).to be_empty
     end
 
-    it 'dispatches a TriggerSchedule with schedule_id, schedule_name and producer_label metadata' do
-      scheduler.schedule('Every minute', '* * * * *') {}
-      scheduler.tick           # baseline
-      advance(60)
-      scheduler.tick
+    it 'materialises the run spec via klass.parse and stamps producer + schedule_name metadata' do
+      schedule_run(scheduler, name: 'My sched', n: 7)
+      scheduler.tick(t0)
+      scheduler.tick(t0 + 60)
 
       expect(store.appended.size).to eq(1)
       msg = store.appended.first
-      expect(msg).to be_a(Sidereal::System::TriggerSchedule)
-      expect(msg.payload.schedule_id).to eq(0)
-      expect(msg.payload.schedule_name).to eq('Every minute')
-      expect(msg.metadata[:producer]).to eq("Schedule #0 'Every minute' (* * * * *)")
+      expect(msg).to be_a(TestSchedRun)
+      expect(msg.payload.n).to eq(7)
+      expect(msg.metadata[:producer]).to eq("Schedule #0 'My sched' (* * * * *)")
+      expect(msg.metadata[:schedule_name]).to eq('My sched')
     end
 
-    it 'dispatches one TriggerSchedule per due schedule, even when crons overlap' do
-      scheduler.schedule('A', '* * * * *') {}
-      scheduler.schedule('B', '* * * * *') {}
-      scheduler.tick
-      advance(60)
-      scheduler.tick
-
-      expect(store.appended.size).to eq(2)
-      expect(store.appended.map { |m| m.payload.schedule_id }).to contain_exactly(0, 1)
-      expect(store.appended.map { |m| m.payload.schedule_name }).to contain_exactly('A', 'B')
-    end
-
-    it 'fires each schedule at most once per tick (no catch-up — matches crond)' do
-      scheduler.schedule('Every minute', '* * * * *') {}
-      scheduler.tick
-      advance(5 * 60 + 30)
-      scheduler.tick
-
+    it 'fires each schedule at most once per tick (no catch-up)' do
+      schedule_run(scheduler)
+      scheduler.tick(t0)
+      scheduler.tick(t0 + 5 * 60 + 30)
       expect(store.appended.size).to eq(1)
     end
 
-    it 'continues running when a store append raises for one schedule' do
+    it 'fires a one-off date-based run_at exactly once and does not refire' do
+      one_off_time = (t0 + 60).iso8601
+      scheduler.schedule 'Once' do |sc|
+        sc.run_at one_off_time, TestSchedRun, n: 1
+      end
+      scheduler.tick(t0)            # warm-up; window empty
+      scheduler.tick(t0 + 120)      # at-time falls in window, fires
+      scheduler.tick(t0 + 240)      # one-off — Fugit::At#next_time returns nil
+      scheduler.tick(t0 + 3600)
+
+      expect(store.appended.count { |m| m.is_a?(TestSchedRun) }).to eq(1)
+    end
+
+    it 'logs and continues when one append raises' do
       flaky = Class.new(RecordingStore) do
         def append(msg)
-          raise 'first one fails' if @appended.empty? && msg.payload.schedule_id.zero?
+          raise 'first one fails' if @appended.empty? && msg.payload.n.zero?
           super
         end
       end.new
-      sched = described_class.new(clock: clock, store: flaky)
-      sched.schedule('A', '* * * * *') {}
-      sched.schedule('B', '* * * * *') {}
+      sched = described_class.new(store: flaky)
+      schedule_run(sched, name: 'A', n: 0)
+      schedule_run(sched, name: 'B', n: 1)
 
-      sched.tick
-      advance(60)
-      sched.tick
+      sched.tick(t0)
+      sched.tick(t0 + 60)
 
-      # Second schedule still gets its TriggerSchedule even though the first raised.
       expect(flaky.appended.size).to eq(1)
-      expect(flaky.appended.first.payload.schedule_id).to eq(1)
-    end
-
-    it 'does not mutate registered Schedules across ticks' do
-      scheduler.schedule('Every minute', '* * * * *') {}
-      original = scheduler.schedules.first
-      scheduler.tick
-      advance(120)
-      scheduler.tick
-      expect(scheduler.schedules.first).to eq(original)
+      expect(flaky.appended.first.payload.n).to eq(1)
     end
   end
 
-  describe '#tick with windowed schedules' do
-    it 'skips a schedule whose from: is still in the future' do
-      scheduler.schedule('Every minute', '* * * * *', from: t0 + 60) {}
-      scheduler.tick           # baseline at t0
-      advance(30)              # now = t0 + 30, before from
-      scheduler.tick
+  describe '#tick — enter/exit dispatch' do
+    it 'dispatches enter when enter_at falls in (baseline, now]' do
+      scheduler.schedule 'Promo' do |sc|
+        sc.run_at '* * * * *', TestSchedRun, n: 1
+        sc.enter_at(t0 + 60, TestSchedEnter)
+      end
+      scheduler.tick(t0)
+      scheduler.tick(t0 + 120)
 
+      enters = store.appended.select { |m| m.is_a?(TestSchedEnter) }
+      expect(enters.size).to eq(1)
+    end
+
+    it 'dispatches exit when exit_at falls in (baseline, now]' do
+      scheduler.schedule 'Promo' do |sc|
+        sc.run_at '* * * * *', TestSchedRun, n: 1
+        sc.exit_at(t0 + 60, TestSchedExit)
+      end
+      scheduler.tick(t0)
+      scheduler.tick(t0 + 120)
+
+      exits = store.appended.select { |m| m.is_a?(TestSchedExit) }
+      expect(exits.size).to eq(1)
+    end
+
+    it 'skips run on the same tick that fires enter (exclusive bound when commanded)' do
+      scheduler.schedule 'Promo' do |sc|
+        sc.run_at '* * * * *', TestSchedRun, n: 1
+        sc.enter_at(t0 + 60, TestSchedEnter)
+      end
+      scheduler.tick(t0)
+      # window (t0, t0+120] contains both enter_at and the cron boundary at t0+60
+      scheduler.tick(t0 + 120)
+
+      enters = store.appended.count { |m| m.is_a?(TestSchedEnter) }
+      runs   = store.appended.count { |m| m.is_a?(TestSchedRun) }
+      expect(enters).to eq(1)
+      expect(runs).to eq(0)
+    end
+
+    it 'skips run on the same tick that fires exit' do
+      scheduler.schedule 'Promo' do |sc|
+        sc.run_at '* * * * *', TestSchedRun, n: 1
+        sc.exit_at(t0 + 60, TestSchedExit)
+      end
+      scheduler.tick(t0)
+      scheduler.tick(t0 + 120)
+
+      exits = store.appended.count { |m| m.is_a?(TestSchedExit) }
+      runs  = store.appended.count { |m| m.is_a?(TestSchedRun) }
+      expect(exits).to eq(1)
+      expect(runs).to eq(0)
+    end
+
+    it 'fires enter then exit, each exactly once, with run firing only between them' do
+      scheduler.schedule 'Window' do |sc|
+        sc.run_at '* * * * *', TestSchedRun, n: 1
+        sc.enter_at(t0 + 60, TestSchedEnter)
+        sc.exit_at(t0 + 180, TestSchedExit)
+      end
+      scheduler.tick(t0)             # warm-up
+      scheduler.tick(t0 + 90)        # crosses enter at t0+60 (run skipped)
+      scheduler.tick(t0 + 150)       # crosses cron boundary at t0+120 (run fires)
+      scheduler.tick(t0 + 270)       # crosses exit at t0+180 (run skipped)
+
+      kinds = store.appended.map(&:class)
+      expect(kinds.count(TestSchedEnter)).to eq(1)
+      expect(kinds.count(TestSchedExit)).to eq(1)
+      expect(kinds.count(TestSchedRun)).to eq(1)
+      expect(kinds.index(TestSchedEnter)).to be < kinds.index(TestSchedRun)
+      expect(kinds.index(TestSchedRun)).to be < kinds.index(TestSchedExit)
+    end
+
+    it 'a bound-only enter_at (no command) does not skip run on the boundary tick' do
+      scheduler.schedule 'BoundOnly' do |sc|
+        sc.run_at '* * * * *', TestSchedRun, n: 1
+        sc.enter_at(t0 + 60)
+      end
+      scheduler.tick(t0)
+      scheduler.tick(t0 + 90)
+
+      runs = store.appended.count { |m| m.is_a?(TestSchedRun) }
+      expect(runs).to eq(1)
+    end
+
+    it 'never fires enter when no enter command is set' do
+      scheduler.schedule 'NoEnter' do |sc|
+        sc.run_at '* * * * *', TestSchedRun, n: 1
+      end
+      5.times { |i| scheduler.tick(t0 + i * 60) }
+      expect(store.appended.none? { |m| m.is_a?(TestSchedEnter) }).to be true
+    end
+  end
+
+  describe '#tick — run dispatch with bounds' do
+    it 'skips run while now < enter_at' do
+      scheduler.schedule 'NotYet' do |sc|
+        sc.run_at '* * * * *', TestSchedRun, n: 1
+        sc.enter_at(t0 + 60)
+      end
+      scheduler.tick(t0)
+      scheduler.tick(t0 + 30)
       expect(store.appended).to be_empty
     end
 
-    it 'fires once from: has passed and a cron boundary fell inside the active window' do
-      scheduler.schedule('Every minute', '* * * * *', from: t0 + 60) {}
-      scheduler.tick           # baseline at t0
-      advance(90)              # now = t0 + 90 — past from + crossed t0+60 minute boundary
-      scheduler.tick
+    it 'stops firing run once now > exit_at' do
+      scheduler.schedule 'Until' do |sc|
+        sc.run_at '* * * * *', TestSchedRun, n: 1
+        sc.exit_at(t0 + 90)
+      end
+      scheduler.tick(t0)
+      scheduler.tick(t0 + 60)
+      expect(store.appended.count { |m| m.is_a?(TestSchedRun) }).to eq(1)
 
-      expect(store.appended.size).to eq(1)
-    end
-
-    it 'fires before to:, skips after to:' do
-      scheduler.schedule('Every minute', '* * * * *', to: t0 + 90) {}
-      scheduler.tick           # baseline at t0
-      advance(60)              # now = t0 + 60 — before to:, boundary crossed
-      scheduler.tick
-      expect(store.appended.size).to eq(1)
-
-      advance(120)             # now = t0 + 180 — past to:
-      scheduler.tick
-      expect(store.appended.size).to eq(1)   # no new fire
-    end
-
-    it 'with both bounds, fires inside the window and skips outside' do
-      scheduler.schedule('Every minute', '* * * * *',
-                         from: t0 + 60, to: t0 + 180) {}
-
-      scheduler.tick           # baseline at t0
-      advance(30)              # before from
-      scheduler.tick
-      expect(store.appended.size).to eq(0)
-
-      advance(60)              # now = t0 + 90 — inside window, boundary at t0+60 crossed
-      scheduler.tick
-      expect(store.appended.size).to eq(1)
-
-      advance(180)             # now = t0 + 270 — past to:
-      scheduler.tick
-      expect(store.appended.size).to eq(1)   # no further fire
-    end
-  end
-
-  describe 'Schedule#run_in' do
-    let(:recorder) do
-      Class.new do
-        attr_reader :seen
-        def record(value); (@seen ||= []) << value; end
-      end.new
-    end
-
-    let(:fake_cmd) { Object.new }
-
-    it 'instance_execs the block on the given context' do
-      scheduler.schedule('Tick', '* * * * *') { record(:fired) }
-      scheduler.find(0).run_in(recorder, fake_cmd)
-
-      expect(recorder.seen).to eq([:fired])
-    end
-
-    it 'yields the triggering cmd to the block' do
-      scheduler.schedule('Tick', '* * * * *') { |cmd| record(cmd) }
-      scheduler.find(0).run_in(recorder, fake_cmd)
-
-      expect(recorder.seen).to eq([fake_cmd])
-    end
-
-    it 'tolerates blocks that do not declare a cmd parameter (proc semantics)' do
-      scheduler.schedule('Tick', '* * * * *') { record(:no_arg_block) }
-      expect { scheduler.find(0).run_in(recorder, fake_cmd) }.not_to raise_error
-      expect(recorder.seen).to eq([:no_arg_block])
+      scheduler.tick(t0 + 180)
+      expect(store.appended.count { |m| m.is_a?(TestSchedRun) }).to eq(1)
     end
   end
 
   describe 'fiber lifecycle' do
     it 'fires at least once when started under a real Async task with a fast tick interval' do
       sched = described_class.new(tick_interval: 0.05, store: store)
-      sched.schedule('Every second', '* * * * * *') {}
+      sched.schedule 'Every second' do |sc|
+        sc.run_at '* * * * * *', TestSchedRun, n: 1
+      end
 
       Sync do |task|
         sched.start(task)
-        # The very-second cron + 50ms tick should fire within ~1.1s.
         sleep 1.2
         task.stop
       end
 
-      expect(store.appended.size).to be >= 1
-      expect(store.appended.first).to be_a(Sidereal::System::TriggerSchedule)
+      runs = store.appended.count { |m| m.is_a?(TestSchedRun) }
+      expect(runs).to be >= 1
     end
   end
 
@@ -335,9 +398,15 @@ RSpec.describe Sidereal::Scheduler do
 
     let(:elector) { test_elector_class.new }
 
+    def add_run_schedule(sched)
+      sched.schedule 'Every second' do |sc|
+        sc.run_at '* * * * * *', TestSchedRun, n: 1
+      end
+    end
+
     it 'does not tick while the elector reports follower' do
       sched = described_class.new(tick_interval: 0.02, store: store, elector: elector)
-      sched.schedule('Every second', '* * * * * *') {}
+      add_run_schedule(sched)
 
       Sync do |task|
         sched.start(task)
@@ -350,12 +419,12 @@ RSpec.describe Sidereal::Scheduler do
 
     it 'starts ticking on promotion and stops on demotion' do
       sched = described_class.new(tick_interval: 0.02, store: store, elector: elector)
-      sched.schedule('Every second', '* * * * * *') {}
+      add_run_schedule(sched)
 
       Sync do |task|
         sched.start(task)
         sleep 0.1
-        expect(store.appended).to be_empty   # not leader yet
+        expect(store.appended).to be_empty
 
         elector.promote!
         sleep 1.2

--- a/spec/scheduler_spec.rb
+++ b/spec/scheduler_spec.rb
@@ -2,13 +2,16 @@
 
 require 'spec_helper'
 
-# Test message classes used by the dumb-Scheduler tests below.
+# Test message classes used by the step-based Scheduler tests below.
+TestSchedFirst  = Sidereal::Message.define('test.sched_first')
+TestSchedSecond = Sidereal::Message.define('test.sched_second')
+TestSchedThird  = Sidereal::Message.define('test.sched_third')
+TestSchedFourth = Sidereal::Message.define('test.sched_fourth')
+TestSchedFifth  = Sidereal::Message.define('test.sched_fifth')
+
 TestSchedRun = Sidereal::Message.define('test.sched_run') do
   attribute :n, Sidereal::Types::Integer
 end
-
-TestSchedEnter = Sidereal::Message.define('test.sched_enter')
-TestSchedExit  = Sidereal::Message.define('test.sched_exit')
 
 # -- Fake store: records appends without async machinery --
 class RecordingStore
@@ -26,178 +29,227 @@ end
 
 RSpec.describe Sidereal::Scheduler do
   let(:store) { RecordingStore.new }
+  let(:t0)    { Time.local(2026, 5, 4, 12, 0, 0) }
 
-  let(:t0) { Time.local(2026, 5, 4, 12, 0, 0) }
+  subject(:scheduler) { described_class.new(store: store, baseline: t0) }
 
-  # Most tests pass an explicit time to +#tick+, so no clock mocking
-  # is needed. The fiber-lifecycle and elector tests at the bottom of
-  # the file still inject a clock since they exercise the
-  # tick-fiber's own scheduling.
-  subject(:scheduler) { described_class.new(store: store) }
-
-  describe '#schedule (builder API)' do
-    it 'is built incrementally and frozen by Scheduler#schedule' do
-      sch = nil
-      scheduler.schedule 'Hourly' do |sc|
-        sc.run_at '0 * * * *', TestSchedRun, n: 7
-        sch = sc
-      end
-
-      expect(sch).to be_frozen
-      expect(sch.name).to eq('Hourly')
-      expect(sch.expression).to eq('0 * * * *')
-      expect(sch.run.klass).to eq(TestSchedRun)
-      expect(sch.run.payload).to eq(n: 7)
-    end
-
-    it 'accepts a pre-built Schedule passed positionally' do
-      built = Sidereal::Scheduler::Schedule.new('X')
-      built.run_at '* * * * *', TestSchedRun, n: 1
-
-      scheduler.schedule(built)
-      expect(scheduler.schedules.size).to eq(1)
-      expect(scheduler.schedules.first).to equal(built)
-    end
-
-    it 'rejects nil/empty schedule names at construction' do
+  describe 'Schedule construction & validation' do
+    it 'raises if name is nil or empty' do
       expect { Sidereal::Scheduler::Schedule.new(nil) }.to raise_error(ArgumentError, /name is required/)
       expect { Sidereal::Scheduler::Schedule.new('')  }.to raise_error(ArgumentError, /name is required/)
     end
 
-    it 'raises when run_at is missing' do
+    it 'raises if a schedule has no steps' do
       expect {
-        scheduler.schedule('NoRun') { |_sc| }
-      }.to raise_error(ArgumentError, /run_at is required/)
+        scheduler.schedule('Empty') { |_sc| }
+      }.to raise_error(ArgumentError, /must declare at least one at/)
     end
 
-    it 'raises on a malformed expression' do
+    it 'raises on an unparseable expression' do
       expect {
-        scheduler.schedule('Bad') do |sc|
-          sc.run_at 'not a cron', TestSchedRun, n: 1
+        scheduler.schedule 'Bad' do |sc|
+          sc.at 'not a real expression', TestSchedFirst
         end
-      }.to raise_error(ArgumentError, /invalid schedule expression/)
+      }.to raise_error(ArgumentError, /invalid expression/)
     end
 
-    it 'requires a class on run_at' do
+    it 'raises if a block is passed to Schedule#at directly (block form is Scheduling-only)' do
       expect {
-        scheduler.schedule('Bare') { |sc| sc.run_at '* * * * *' }
-      }.to raise_error(ArgumentError, /run_at requires a command class/)
-    end
-
-    it 'coerces enter_at strings to Time' do
-      scheduler.schedule 'Strs' do |sc|
-        sc.run_at '* * * * *', TestSchedRun, n: 1
-        sc.enter_at '2026-06-01T00:00:00Z'
-      end
-      expect(scheduler.schedules.first.enter_at).to eq(Time.utc(2026, 6, 1))
-    end
-
-    it 'accepts a callable exit_at receiving the resolved enter_at' do
-      enter = Time.local(2026, 6, 1, 12)
-      scheduler.schedule 'Window' do |sc|
-        sc.run_at '* * * * *', TestSchedRun, n: 1
-        sc.enter_at enter
-        sc.exit_at ->(e) { e + 3600 }
-      end
-      expect(scheduler.schedules.first.exit_at).to eq(enter + 3600)
-    end
-
-    it 'raises with a guidance-rich message when exit_at is callable without an enter_at' do
-      expect {
-        scheduler.schedule 'BadExit' do |sc|
-          sc.run_at '* * * * *', TestSchedRun, n: 1
-          sc.exit_at ->(e) { e + 60 }
+        scheduler.schedule 'NoBlocks' do |sc|
+          sc.at('every minute') {}
         end
-      }.to raise_error(ArgumentError) { |err|
-        expect(err.message).to include('"BadExit"')
-        expect(err.message).to include('exit_at was given a callable but no enter_at is set')
-        expect(err.message).to include('declare enter_at')
-        expect(err.message).to include('static Time/String/DateTime')
-      }
+      }.to raise_error(ArgumentError, /block form is supported only via Sidereal::Scheduling/)
     end
 
-    it 'accepts a Fugit duration string for exit_at, resolved relative to enter_at' do
-      enter = Time.utc(2026, 1, 1, 12, 0, 0)
-      scheduler.schedule 'PromoYear' do |sc|
-        sc.run_at '0 0 * * *', TestSchedRun, n: 1
-        sc.enter_at enter
-        sc.exit_at '12y12M', TestSchedExit
-      end
-
-      sch = scheduler.schedules.first
-      expect(sch.exit_at).to be_a(Time)
-      expect(sch.exit_at.year).to eq(2039)
-      expect(sch.exit_at.month).to eq(1)
-      expect(sch.exit.klass).to eq(TestSchedExit)
-    end
-
-    it 'accepts shorter duration strings (e.g. 1h30m) and ISO8601 (P1H30M-style) forms' do
-      enter = Time.utc(2026, 1, 1, 12)
-      scheduler.schedule 'Hourly' do |sc|
-        sc.run_at '* * * * *', TestSchedRun, n: 1
-        sc.enter_at enter
-        sc.exit_at '1h30m'
-      end
-
-      expect(scheduler.schedules.first.exit_at).to eq(enter + 90 * 60)
-    end
-
-    it 'raises with a duration-specific message when exit_at is a duration without an enter_at' do
+    it 'raises when a specific datetime travels backwards relative to a previous concrete step' do
       expect {
-        scheduler.schedule 'NoEnter' do |sc|
-          sc.run_at '* * * * *', TestSchedRun, n: 1
-          sc.exit_at '1h30m'
+        scheduler.schedule 'Backwards' do |sc|
+          sc.at '2026-06-01T12:00:00', TestSchedFirst
+          sc.at '2026-05-01T12:00:00', TestSchedSecond
         end
-      }.to raise_error(ArgumentError) { |err|
-        expect(err.message).to include('"NoEnter"')
-        expect(err.message).to include('exit_at was given a duration but no enter_at is set')
-        expect(err.message).to include('Durations are resolved relative to enter_at')
-        expect(err.message).to include('declare enter_at')
-        expect(err.message).to include('static Time/String/DateTime')
-      }
+      }.to raise_error(ArgumentError, /must be after the previous concrete time/)
     end
 
-    it 'allows a static exit_at without an enter_at' do
-      scheduler.schedule 'BoundedAbove' do |sc|
-        sc.run_at '* * * * *', TestSchedRun, n: 1
-        sc.exit_at '2026-12-31T00:00:00Z'
-      end
-
-      sch = scheduler.schedules.first
-      expect(sch.enter_at).to be_nil
-      expect(sch.exit_at).to eq(Time.utc(2026, 12, 31))
-    end
-
-    it 'raises when both bounds are present and the cron never fires inside the window' do
+    it 'raises when two recurring steps follow each other without a concrete bound between them' do
       expect {
-        scheduler.schedule 'TooTight' do |sc|
-          sc.run_at '5 0 * * *', TestSchedRun, n: 1
-          sc.enter_at Time.local(2026, 6, 1, 12)
-          sc.exit_at  Time.local(2026, 6, 1, 12, 30)
+        scheduler.schedule 'BackToBack' do |sc|
+          sc.at 'every minute', TestSchedFirst
+          sc.at 'every hour',   TestSchedSecond
         end
-      }.to raise_error(ArgumentError, /never fires inside the window/)
+      }.to raise_error(ArgumentError, /must separate two recurring/)
+    end
+
+    it 'allows a past first specific datetime (it just never fires)' do
+      expect {
+        scheduler.schedule 'Past' do |sc|
+          sc.at '2025-01-01T00:00:00', TestSchedFirst
+          sc.at '5m', TestSchedSecond   # resolves against the past first step
+        end
+      }.not_to raise_error
     end
 
     it 'rejects non-String, non-Schedule first argument' do
       expect { scheduler.schedule(42) }.to raise_error(ArgumentError, /expected Schedule or String name/)
     end
-  end
 
-  describe '#tick — run dispatch' do
-    def schedule_run(scheduler, name: 'My sched', n: 1, exp: '* * * * *')
-      scheduler.schedule name do |sc|
-        sc.run_at exp, TestSchedRun, n: n
+    it 'accepts a Time instance as a specific step expression' do
+      target = t0 + 10
+      scheduler.schedule 'TimeInput' do |sc|
+        sc.at target, TestSchedFirst
       end
+
+      step = scheduler.schedules.first.steps.first
+      expect(step).to be_a(Sidereal::Scheduler::Schedule::Step::Specific)
+      expect(step.at).to eq(target)
     end
 
+    it 'accepts a DateTime instance (any to_time responder) as a specific step expression' do
+      require 'date'
+      target = DateTime.new(2026, 6, 1, 12, 0, 0)
+      scheduler.schedule 'DateTimeInput' do |sc|
+        sc.at target, TestSchedFirst
+      end
+
+      step = scheduler.schedules.first.steps.first
+      expect(step).to be_a(Sidereal::Scheduler::Schedule::Step::Specific)
+      expect(step.at).to eq(target.to_time)
+    end
+
+    it 'accepts a Time as a bound-only marker (no class)' do
+      target = t0 + 10
+      scheduler.schedule 'TimeMarker' do |sc|
+        sc.at target
+        sc.at 'every minute', TestSchedRun, n: 1
+      end
+
+      sch = scheduler.schedules.first
+      expect(sch.steps[0].klass).to be_nil
+      expect(sch.steps[0].at).to eq(target)
+      expect(sch.steps[1].from).to eq(target)
+    end
+
+    it 'allows a bound-only marker step (specific datetime, no class) — anchors but never fires' do
+      scheduler.schedule 'Anchor + recurring' do |sc|
+        sc.at '2026-05-04T10:00:00'        # marker — no class
+        sc.at '*/5 * * * *', TestSchedRun, n: 1
+      end
+
+      sch = scheduler.schedules.first
+      expect(sch.steps[0]).to be_a(Sidereal::Scheduler::Schedule::Step::Specific)
+      expect(sch.steps[0].klass).to be_nil
+      expect(sch.steps[1]).to be_a(Sidereal::Scheduler::Schedule::Step::Recurring)
+      expect(sch.steps[1].from).to eq(Time.parse('2026-05-04T10:00:00'))
+    end
+
+    it 'allows a bound-only duration marker — anchors a relative point without dispatching' do
+      scheduler.schedule 'Delayed start' do |sc|
+        sc.at '5m'                          # marker — boot + 5m, no class
+        sc.at 'every minute', TestSchedRun, n: 1
+      end
+
+      sch = scheduler.schedules.first
+      expect(sch.steps[0].klass).to be_nil
+      expect(sch.steps[0].at).to eq(t0 + 5 * 60)
+      expect(sch.steps[1].from).to eq(t0 + 5 * 60)
+    end
+
+    it 'raises when a recurring step has no class (bound-only recurring is meaningless)' do
+      expect {
+        scheduler.schedule 'BadMarker' do |sc|
+          sc.at 'every minute'   # recurring with no class — would fire nothing forever
+        end
+      }.to raise_error(ArgumentError, /recurring step.*requires a command class/)
+    end
+
+    it 'accepts a pre-built Schedule passed positionally' do
+      built = Sidereal::Scheduler::Schedule.new('Pre')
+      built.at '* * * * *', TestSchedRun, n: 1
+
+      scheduler.schedule(built)
+      expect(scheduler.schedules.size).to eq(1)
+      expect(scheduler.schedules.first).to equal(built)
+    end
+  end
+
+  describe 'resolution walk (Campaign 1)' do
+    it 'resolves the user example end-to-end with the right step types and times' do
+      scheduler.schedule 'Campaign 1' do |sc|
+        sc.at '2026-05-03T10:00:00', TestSchedFirst   # T0
+        sc.at '3m',                  TestSchedSecond  # T0 + 3m
+        sc.at '*/5 * * * *',           TestSchedThird   # recurring from T0+3m
+        sc.at '10h',                 TestSchedFourth  # T0 + 3m + 10h
+        sc.at '2026-05-06T09:00:00', TestSchedFifth   # closes nothing; pure specific
+      end
+
+      sch = scheduler.schedules.first
+      steps = sch.steps
+      expect(steps.size).to eq(5)
+
+      t0 = Time.parse('2026-05-03T10:00:00')
+      t1 = t0 + 3 * 60                  # T0 + 3m
+      t2 = t1 + 10 * 3600               # T1 + 10h
+      t3 = Time.parse('2026-05-06T09:00:00')
+
+      expect(steps[0]).to be_a(Sidereal::Scheduler::Schedule::Step::Specific)
+      expect(steps[0].at).to eq(t0)
+
+      expect(steps[1]).to be_a(Sidereal::Scheduler::Schedule::Step::Specific)
+      expect(steps[1].at).to eq(t1)
+
+      expect(steps[2]).to be_a(Sidereal::Scheduler::Schedule::Step::Recurring)
+      expect(steps[2].from).to eq(t1)
+      expect(steps[2].to).to eq(t2)             # closed by the duration step
+
+      expect(steps[3]).to be_a(Sidereal::Scheduler::Schedule::Step::Specific)
+      expect(steps[3].at).to eq(t2)
+
+      expect(steps[4]).to be_a(Sidereal::Scheduler::Schedule::Step::Specific)
+      expect(steps[4].at).to eq(t3)
+    end
+
+    it 'leaves a trailing recurring step open-ended (to: nil)' do
+      scheduler.schedule 'Forever' do |sc|
+        sc.at '2026-05-03T10:00:00', TestSchedFirst
+        sc.at 'every minute',        TestSchedSecond
+      end
+
+      step = scheduler.schedules.first.steps.last
+      expect(step).to be_a(Sidereal::Scheduler::Schedule::Step::Recurring)
+      expect(step.to).to be_nil
+    end
+
+    it 'a duration as the first step resolves against the Scheduler baseline' do
+      scheduler.schedule 'Boot+5m' do |sc|
+        sc.at '5m', TestSchedFirst
+      end
+      step = scheduler.schedules.first.steps.first
+      expect(step.at).to eq(t0 + 5 * 60)
+    end
+
+    it 'a recurring as the first step has from == baseline and is open-ended' do
+      scheduler.schedule 'Forever from boot' do |sc|
+        sc.at 'every minute', TestSchedFirst
+      end
+      step = scheduler.schedules.first.steps.first
+      expect(step).to be_a(Sidereal::Scheduler::Schedule::Step::Recurring)
+      expect(step.from).to eq(t0)
+      expect(step.to).to be_nil
+    end
+  end
+
+  describe '#tick' do
     it 'fires nothing on the first tick (window is empty)' do
-      schedule_run(scheduler)
+      scheduler.schedule 'A' do |sc|
+        sc.at 'every minute', TestSchedRun, n: 1
+      end
       scheduler.tick(t0)
       expect(store.appended).to be_empty
     end
 
-    it 'materialises the run spec via klass.parse and stamps producer + schedule_name metadata' do
-      schedule_run(scheduler, name: 'My sched', n: 7)
+    it 'materialises the step via klass.parse and stamps producer + schedule_name metadata' do
+      scheduler.schedule 'My sched' do |sc|
+        sc.at 'every minute', TestSchedRun, n: 7
+      end
       scheduler.tick(t0)
       scheduler.tick(t0 + 60)
 
@@ -205,173 +257,123 @@ RSpec.describe Sidereal::Scheduler do
       msg = store.appended.first
       expect(msg).to be_a(TestSchedRun)
       expect(msg.payload.n).to eq(7)
-      expect(msg.metadata[:producer]).to eq("Schedule #0 'My sched' (* * * * *)")
+      expect(msg.metadata[:producer]).to eq("Schedule #0 'My sched' step #0 (every minute)")
       expect(msg.metadata[:schedule_name]).to eq('My sched')
     end
 
-    it 'fires each schedule at most once per tick (no catch-up)' do
-      schedule_run(scheduler)
+    it 'fires each step at most once per tick (no catch-up)' do
+      scheduler.schedule 'A' do |sc|
+        sc.at 'every minute', TestSchedRun, n: 1
+      end
       scheduler.tick(t0)
       scheduler.tick(t0 + 5 * 60 + 30)
       expect(store.appended.size).to eq(1)
     end
 
-    it 'fires a one-off date-based run_at exactly once and does not refire' do
-      one_off_time = (t0 + 60).iso8601
+    it 'a one-off ISO8601 expression fires exactly once and does not refire' do
       scheduler.schedule 'Once' do |sc|
-        sc.run_at one_off_time, TestSchedRun, n: 1
+        sc.at (t0 + 60).iso8601, TestSchedRun, n: 1
       end
       scheduler.tick(t0)            # warm-up; window empty
-      scheduler.tick(t0 + 120)      # at-time falls in window, fires
-      scheduler.tick(t0 + 240)      # one-off — Fugit::At#next_time returns nil
+      scheduler.tick(t0 + 120)      # specific instant in window — fires
+      scheduler.tick(t0 + 240)
       scheduler.tick(t0 + 3600)
 
       expect(store.appended.count { |m| m.is_a?(TestSchedRun) }).to eq(1)
     end
 
+    it 'a bound-only marker step never appends to the store, even when its instant is in the window' do
+      scheduler.schedule 'Marker' do |sc|
+        sc.at (t0 + 60).iso8601         # marker — no klass
+        sc.at 'every minute', TestSchedRun, n: 1
+      end
+
+      scheduler.tick(t0)
+      scheduler.tick(t0 + 120)          # marker's instant in window AND a cron boundary
+
+      # Only the recurring fires; no marker dispatch.
+      expect(store.appended.size).to eq(1)
+      expect(store.appended.first).to be_a(TestSchedRun)
+    end
+
     it 'logs and continues when one append raises' do
       flaky = Class.new(RecordingStore) do
         def append(msg)
-          raise 'first one fails' if @appended.empty? && msg.payload.n.zero?
+          raise 'boom' if @appended.empty? && msg.is_a?(TestSchedFirst)
           super
         end
       end.new
-      sched = described_class.new(store: flaky)
-      schedule_run(sched, name: 'A', n: 0)
-      schedule_run(sched, name: 'B', n: 1)
+      sched = described_class.new(store: flaky, baseline: t0)
+      sched.schedule 'A' do |sc|
+        sc.at 'every minute', TestSchedFirst
+      end
+      sched.schedule 'B' do |sc|
+        sc.at 'every minute', TestSchedSecond
+      end
 
       sched.tick(t0)
       sched.tick(t0 + 60)
 
       expect(flaky.appended.size).to eq(1)
-      expect(flaky.appended.first.payload.n).to eq(1)
+      expect(flaky.appended.first).to be_a(TestSchedSecond)
     end
   end
 
-  describe '#tick — enter/exit dispatch' do
-    it 'dispatches enter when enter_at falls in (baseline, now]' do
-      scheduler.schedule 'Promo' do |sc|
-        sc.run_at '* * * * *', TestSchedRun, n: 1
-        sc.enter_at(t0 + 60, TestSchedEnter)
+  describe '#tick — Campaign 1 end-to-end' do
+    it 'fires each step at the right time and respects the recurring upper bound' do
+      scheduler.schedule 'Campaign 1' do |sc|
+        sc.at '2026-05-03T10:00:00', TestSchedFirst    # T0
+        sc.at '3m',                  TestSchedSecond   # T0 + 3m
+        sc.at '*/5 * * * *',           TestSchedThird    # recurring (every 5 minutes) from T1 to T2
+        sc.at '10h',                 TestSchedFourth   # T2 = T1 + 10h
+        sc.at '2026-05-06T09:00:00', TestSchedFifth    # T3
       end
-      scheduler.tick(t0)
-      scheduler.tick(t0 + 120)
 
-      enters = store.appended.select { |m| m.is_a?(TestSchedEnter) }
-      expect(enters.size).to eq(1)
-    end
+      campaign_t0 = Time.parse('2026-05-03T10:00:00')
+      t1 = campaign_t0 + 3 * 60
+      t2 = t1 + 10 * 3600
+      t3 = Time.parse('2026-05-06T09:00:00')
 
-    it 'dispatches exit when exit_at falls in (baseline, now]' do
-      scheduler.schedule 'Promo' do |sc|
-        sc.run_at '* * * * *', TestSchedRun, n: 1
-        sc.exit_at(t0 + 60, TestSchedExit)
-      end
-      scheduler.tick(t0)
-      scheduler.tick(t0 + 120)
-
-      exits = store.appended.select { |m| m.is_a?(TestSchedExit) }
-      expect(exits.size).to eq(1)
-    end
-
-    it 'skips run on the same tick that fires enter (exclusive bound when commanded)' do
-      scheduler.schedule 'Promo' do |sc|
-        sc.run_at '* * * * *', TestSchedRun, n: 1
-        sc.enter_at(t0 + 60, TestSchedEnter)
-      end
-      scheduler.tick(t0)
-      # window (t0, t0+120] contains both enter_at and the cron boundary at t0+60
-      scheduler.tick(t0 + 120)
-
-      enters = store.appended.count { |m| m.is_a?(TestSchedEnter) }
-      runs   = store.appended.count { |m| m.is_a?(TestSchedRun) }
-      expect(enters).to eq(1)
-      expect(runs).to eq(0)
-    end
-
-    it 'skips run on the same tick that fires exit' do
-      scheduler.schedule 'Promo' do |sc|
-        sc.run_at '* * * * *', TestSchedRun, n: 1
-        sc.exit_at(t0 + 60, TestSchedExit)
-      end
-      scheduler.tick(t0)
-      scheduler.tick(t0 + 120)
-
-      exits = store.appended.count { |m| m.is_a?(TestSchedExit) }
-      runs  = store.appended.count { |m| m.is_a?(TestSchedRun) }
-      expect(exits).to eq(1)
-      expect(runs).to eq(0)
-    end
-
-    it 'fires enter then exit, each exactly once, with run firing only between them' do
-      scheduler.schedule 'Window' do |sc|
-        sc.run_at '* * * * *', TestSchedRun, n: 1
-        sc.enter_at(t0 + 60, TestSchedEnter)
-        sc.exit_at(t0 + 180, TestSchedExit)
-      end
-      scheduler.tick(t0)             # warm-up
-      scheduler.tick(t0 + 90)        # crosses enter at t0+60 (run skipped)
-      scheduler.tick(t0 + 150)       # crosses cron boundary at t0+120 (run fires)
-      scheduler.tick(t0 + 270)       # crosses exit at t0+180 (run skipped)
-
-      kinds = store.appended.map(&:class)
-      expect(kinds.count(TestSchedEnter)).to eq(1)
-      expect(kinds.count(TestSchedExit)).to eq(1)
-      expect(kinds.count(TestSchedRun)).to eq(1)
-      expect(kinds.index(TestSchedEnter)).to be < kinds.index(TestSchedRun)
-      expect(kinds.index(TestSchedRun)).to be < kinds.index(TestSchedExit)
-    end
-
-    it 'a bound-only enter_at (no command) does not skip run on the boundary tick' do
-      scheduler.schedule 'BoundOnly' do |sc|
-        sc.run_at '* * * * *', TestSchedRun, n: 1
-        sc.enter_at(t0 + 60)
-      end
-      scheduler.tick(t0)
-      scheduler.tick(t0 + 90)
-
-      runs = store.appended.count { |m| m.is_a?(TestSchedRun) }
-      expect(runs).to eq(1)
-    end
-
-    it 'never fires enter when no enter command is set' do
-      scheduler.schedule 'NoEnter' do |sc|
-        sc.run_at '* * * * *', TestSchedRun, n: 1
-      end
-      5.times { |i| scheduler.tick(t0 + i * 60) }
-      expect(store.appended.none? { |m| m.is_a?(TestSchedEnter) }).to be true
-    end
-  end
-
-  describe '#tick — run dispatch with bounds' do
-    it 'skips run while now < enter_at' do
-      scheduler.schedule 'NotYet' do |sc|
-        sc.run_at '* * * * *', TestSchedRun, n: 1
-        sc.enter_at(t0 + 60)
-      end
-      scheduler.tick(t0)
-      scheduler.tick(t0 + 30)
+      # Tick before T0 — nothing fires.
+      scheduler.tick(campaign_t0 - 60)
       expect(store.appended).to be_empty
-    end
 
-    it 'stops firing run once now > exit_at' do
-      scheduler.schedule 'Until' do |sc|
-        sc.run_at '* * * * *', TestSchedRun, n: 1
-        sc.exit_at(t0 + 90)
-      end
-      scheduler.tick(t0)
-      scheduler.tick(t0 + 60)
-      expect(store.appended.count { |m| m.is_a?(TestSchedRun) }).to eq(1)
+      # Tick across T0 — TestSchedFirst fires.
+      scheduler.tick(campaign_t0 + 1)
+      expect(store.appended.last).to be_a(TestSchedFirst)
 
-      scheduler.tick(t0 + 180)
-      expect(store.appended.count { |m| m.is_a?(TestSchedRun) }).to eq(1)
+      # Tick across T1 — TestSchedSecond fires.
+      scheduler.tick(t1 + 1)
+      expect(store.appended.last).to be_a(TestSchedSecond)
+
+      # During the recurring window, every-5-minute boundaries fire
+      # TestSchedThird. Tick over the next 10 minutes.
+      scheduler.tick(t1 + 5 * 60 + 10)   # crosses 10:08 (next 5/* boundary at 10:05)
+      expect(store.appended.last).to be_a(TestSchedThird)
+      scheduler.tick(t1 + 10 * 60 + 10)  # crosses 10:13 (next at 10:10)
+      expect(store.appended.last).to be_a(TestSchedThird)
+      thirds_count = store.appended.count { |m| m.is_a?(TestSchedThird) }
+
+      # Tick past T2 — TestSchedFourth fires; the recurring window
+      # should be closed (no more TestSchedThird).
+      scheduler.tick(t2 + 1)
+      expect(store.appended.last).to be_a(TestSchedFourth)
+
+      # Far past T2 — no more TestSchedThird.
+      scheduler.tick(t2 + 3600)
+      expect(store.appended.count { |m| m.is_a?(TestSchedThird) }).to eq(thirds_count)
+
+      # Tick across T3 — TestSchedFifth fires.
+      scheduler.tick(t3 + 1)
+      expect(store.appended.last).to be_a(TestSchedFifth)
     end
   end
 
   describe 'fiber lifecycle' do
     it 'fires at least once when started under a real Async task with a fast tick interval' do
       sched = described_class.new(tick_interval: 0.05, store: store)
-      sched.schedule 'Every second' do |sc|
-        sc.run_at '* * * * * *', TestSchedRun, n: 1
+      sched.schedule 'Tick' do |sc|
+        sc.at '* * * * * *', TestSchedRun, n: 1
       end
 
       Sync do |task|
@@ -380,8 +382,7 @@ RSpec.describe Sidereal::Scheduler do
         task.stop
       end
 
-      runs = store.appended.count { |m| m.is_a?(TestSchedRun) }
-      expect(runs).to be >= 1
+      expect(store.appended.count { |m| m.is_a?(TestSchedRun) }).to be >= 1
     end
   end
 
@@ -399,8 +400,8 @@ RSpec.describe Sidereal::Scheduler do
     let(:elector) { test_elector_class.new }
 
     def add_run_schedule(sched)
-      sched.schedule 'Every second' do |sc|
-        sc.run_at '* * * * * *', TestSchedRun, n: 1
+      sched.schedule 'Tick' do |sc|
+        sc.at '* * * * * *', TestSchedRun, n: 1
       end
     end
 

--- a/spec/scheduler_spec.rb
+++ b/spec/scheduler_spec.rb
@@ -163,16 +163,33 @@ RSpec.describe Sidereal::Scheduler do
   end
 
   describe 'Schedule#run_in' do
-    it 'instance_execs the block on the given context' do
-      recorder = Class.new do
+    let(:recorder) do
+      Class.new do
         attr_reader :seen
         def record(value); (@seen ||= []) << value; end
       end.new
+    end
 
+    let(:fake_cmd) { Object.new }
+
+    it 'instance_execs the block on the given context' do
       scheduler.schedule('* * * * *') { record(:fired) }
-      scheduler.find(0).run_in(recorder)
+      scheduler.find(0).run_in(recorder, fake_cmd)
 
       expect(recorder.seen).to eq([:fired])
+    end
+
+    it 'yields the triggering cmd to the block' do
+      scheduler.schedule('* * * * *') { |cmd| record(cmd) }
+      scheduler.find(0).run_in(recorder, fake_cmd)
+
+      expect(recorder.seen).to eq([fake_cmd])
+    end
+
+    it 'tolerates blocks that do not declare a cmd parameter (proc semantics)' do
+      scheduler.schedule('* * * * *') { record(:no_arg_block) }
+      expect { scheduler.find(0).run_in(recorder, fake_cmd) }.not_to raise_error
+      expect(recorder.seen).to eq([:no_arg_block])
     end
   end
 
@@ -189,24 +206,28 @@ RSpec.describe Sidereal::Scheduler do
       expect(Sidereal.scheduler.schedules.first.cron_expr).to eq('*/5 * * * *')
     end
 
-    it 'TriggerSchedule handler runs the schedule block in the Commander instance' do
+    it 'TriggerSchedule handler runs the schedule block in the Commander instance and yields the cmd' do
       app_class = Class.new(Sidereal::App) do
         command SchedTick do |_cmd|
           # registered so dispatch routes SchedTick to commands, not events
         end
-        schedule '*/5 * * * *' do
-          dispatch SchedTick, n: 42
+        schedule '*/5 * * * *' do |cmd|
+          # Read the producer from the cmd's metadata to prove the cmd is yielded.
+          dispatch SchedTick, n: cmd.metadata[:producer].length
         end
       end
 
       sch = Sidereal.scheduler.schedules.first
-      trigger = Sidereal::System::TriggerSchedule.new(payload: { schedule_id: sch.id })
+      trigger = Sidereal::System::TriggerSchedule.new(
+        payload: { schedule_id: sch.id },
+        metadata: { producer: sch.name }
+      )
       result = app_class.commander.handle(trigger, pubsub: FakePubSub.new)
 
       expect(result.commands.size).to eq(1)
       dispatched = result.commands.first
       expect(dispatched).to be_a(SchedTick)
-      expect(dispatched.payload.n).to eq(42)
+      expect(dispatched.payload.n).to eq(sch.name.length)
       # Causation chain: the dispatched command points back at the TriggerSchedule.
       expect(dispatched.causation_id).to eq(trigger.id)
       expect(dispatched.correlation_id).to eq(trigger.correlation_id)

--- a/spec/scheduling_spec.rb
+++ b/spec/scheduling_spec.rb
@@ -1,0 +1,282 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Test message classes — lightweight stand-ins for whatever a host
+# would dispatch through its scheduler.
+TestSchedulingTick = Sidereal::Message.define('test.scheduling_tick') do
+  attribute :n, Sidereal::Types::Integer
+end
+
+TestSchedulingExit = Sidereal::Message.define('test.scheduling_exit')
+
+RSpec.describe Sidereal::Scheduling do
+  before { Sidereal.reset_scheduler! }
+  after  { Sidereal.reset_scheduler! }
+
+  # A minimal stand-in that satisfies the Scheduling mixin's host
+  # contract: it just needs to expose +.command(klass, &block)+. The
+  # generated handlers are recorded so tests can inspect them; no
+  # actual command-handling pipeline runs here. This isolates the
+  # mixin's behaviour from any Commander-specific machinery.
+  def make_test_host(const_name, &body)
+    cls = Class.new do
+      def self.commands_registered
+        @commands_registered ||= {}
+      end
+
+      def self.command(klass, &block)
+        commands_registered[klass] = block
+        self
+      end
+
+      include Sidereal::Scheduling
+    end
+    Object.const_set(const_name, cls)
+    cls.class_eval(&body) if body
+    cls
+  end
+
+  after do
+    %i[HostA HostB HostC HostD HostE HostF].each do |c|
+      Object.send(:remove_const, c) if Object.const_defined?(c, false)
+    end
+  end
+
+  describe 'host contract' do
+    it 'creates a Schedules namespace on the host when included' do
+      host = make_test_host(:HostA)
+      expect(host::Schedules).to be_a(Module)
+    end
+
+    it 'gives each subclass its own Schedules namespace' do
+      host = make_test_host(:HostA)
+      sub  = Class.new(host)
+
+      expect(sub::Schedules).not_to equal(host::Schedules)
+    end
+
+    it 'is host-agnostic — works on any class that exposes #command' do
+      # No Commander, no App, no Sidereal::Message inheritance — just a
+      # class with a +command+ class method.
+      host = make_test_host(:HostA) do
+        schedule 'Hourly', '0 * * * *' do |_cmd| end
+      end
+
+      expect(host::Schedules.const_defined?(:SchedHourly0Step0, false)).to be true
+      expect(Sidereal.scheduler.schedules.first.name).to eq('Hourly')
+    end
+  end
+
+  describe 'single-step shorthand (name, expression, &block)' do
+    it 'registers a one-step schedule with the block as that step’s handler' do
+      host = make_test_host(:HostA) do
+        schedule 'Cleanup', '*/5 * * * *' do |_cmd| end
+      end
+
+      expect(host::Schedules.const_defined?(:SchedCleanup0Step0, false)).to be true
+
+      sch = Sidereal.scheduler.schedules.first
+      expect(sch.name).to eq('Cleanup')
+      expect(sch.steps.size).to eq(1)
+      expect(sch.steps.first.expression).to eq('*/5 * * * *')
+      expect(sch.steps.first.klass).to eq(host::Schedules::SchedCleanup0Step0)
+    end
+
+    it 'records the user block on the host as the handler for the generated step class' do
+      handler_block = nil
+      host = make_test_host(:HostB) do
+        schedule 'Cleanup', '*/5 * * * *' do |cmd|
+          # body of the handler — captured by the host's #command
+          cmd.metadata[:schedule_name]
+        end
+      end
+
+      step_class = host::Schedules::SchedCleanup0Step0
+      handler_block = host.commands_registered[step_class]
+
+      expect(handler_block).to be_a(Proc)
+      expect(handler_block.arity).to eq(1)
+    end
+
+    it 'accepts a Time instance as the shorthand expression' do
+      target = Time.local(2026, 5, 4, 12, 0, 0)
+      make_test_host(:HostC) do
+        schedule 'Once', target do |_cmd| end
+      end
+
+      sch = Sidereal.scheduler.schedules.first
+      expect(sch.steps.first.at).to eq(target)
+    end
+
+    it 'raises if the shorthand block has the wrong arity' do
+      expect {
+        make_test_host(:HostD) do
+          schedule 'Bad', '*/5 * * * *' do
+            # arity 0 with an expression — invalid for shorthand
+          end
+        end
+      }.to raise_error(ArgumentError, /requires a block of arity 1/)
+    end
+  end
+
+  describe 'multi-step block form (auto-generated step classes)' do
+    it 'generates one class per step under <Host>::Schedules and registers each with Sidereal.scheduler' do
+      host = make_test_host(:HostA) do
+        schedule 'Tick campaign' do
+          at '2026-05-06T15:00:00' do |_cmd| end
+          at 'every 3 seconds'    do |_cmd| end
+          at '30s'                do |_cmd| end
+        end
+      end
+
+      expect(host::Schedules.const_defined?(:SchedTickCampaign0Step0, false)).to be true
+      expect(host::Schedules.const_defined?(:SchedTickCampaign0Step1, false)).to be true
+      expect(host::Schedules.const_defined?(:SchedTickCampaign0Step2, false)).to be true
+
+      step0 = host::Schedules::SchedTickCampaign0Step0
+      expect(step0.type).to eq('host_a.schedules.tick_campaign_0_step_0')
+
+      sch = Sidereal.scheduler.schedules.first
+      expect(sch.name).to eq('Tick campaign')
+      expect(sch.steps.map(&:klass)).to eq([
+        host::Schedules::SchedTickCampaign0Step0,
+        host::Schedules::SchedTickCampaign0Step1,
+        host::Schedules::SchedTickCampaign0Step2
+      ])
+    end
+
+    it 'records each step block on the host as the handler for its generated class' do
+      host = make_test_host(:HostB) do
+        schedule 'Three' do
+          at '2026-05-04T10:00:00' do |_cmd| end
+          at 'every minute'        do |_cmd| end
+          at '5m'                  do |_cmd| end
+        end
+      end
+
+      [:SchedThree0Step0, :SchedThree0Step1, :SchedThree0Step2].each do |const|
+        klass = host::Schedules.const_get(const)
+        expect(host.commands_registered[klass]).to be_a(Proc)
+      end
+    end
+  end
+
+  describe 'explicit-class form (klass + payload, no block)' do
+    it 'passes the user-supplied class through to the Scheduler without generating a class or handler' do
+      host = make_test_host(:HostA) do
+        schedule 'Flash sale campaign' do
+          at '2026-05-10T10:00:00', TestSchedulingTick, n: 1
+          at 'every day at 9am',    TestSchedulingTick, n: 2
+          at '10d',                 TestSchedulingExit
+        end
+      end
+
+      expect(host::Schedules.constants).to be_empty
+      expect(host.commands_registered).to be_empty
+
+      sch = Sidereal.scheduler.schedules.first
+      expect(sch.steps.size).to eq(3)
+      expect(sch.steps[0].klass).to eq(TestSchedulingTick)
+      expect(sch.steps[0].payload).to eq(n: 1)
+      expect(sch.steps[2].klass).to eq(TestSchedulingExit)
+      expect(sch.steps[2].payload).to eq({})
+    end
+
+    it 'allows mixing block and explicit forms across steps' do
+      host = make_test_host(:HostB) do
+        schedule 'Mixed' do
+          at '2026-05-10T10:00:00' do |_cmd| end                # generated
+          at 'every minute', TestSchedulingTick, n: 1           # explicit
+          at '1h',           TestSchedulingExit                 # explicit
+        end
+      end
+
+      expect(host::Schedules.const_defined?(:SchedMixed0Step0, false)).to be true
+      expect(host::Schedules.const_defined?(:SchedMixed0Step1, false)).to be false
+      expect(host::Schedules.const_defined?(:SchedMixed0Step2, false)).to be false
+
+      sch = Sidereal.scheduler.schedules.first
+      expect(sch.steps[1].klass).to eq(TestSchedulingTick)
+      expect(sch.steps[2].klass).to eq(TestSchedulingExit)
+    end
+
+    it 'raises when both a block and a class are supplied to the same at' do
+      expect {
+        make_test_host(:HostC) do
+          schedule 'Both' do
+            at 'every minute', TestSchedulingTick, n: 1 do |_cmd| end
+          end
+        end
+      }.to raise_error(ArgumentError, /pass either a block or a command class, not both/)
+    end
+
+    it 'a recurring step with neither a block nor a class raises (bound-only recurring is meaningless)' do
+      expect {
+        make_test_host(:HostD) do
+          schedule 'BadMarker' do
+            at 'every minute'
+          end
+        end
+      }.to raise_error(ArgumentError, /recurring step.*requires a command class/)
+    end
+
+    it 'a specific or duration step with no class is a bound-only marker (anchors the timeline, never dispatches)' do
+      host = make_test_host(:HostA) do
+        schedule 'Campaign' do
+          at '2026-05-04T10:00:00'                          # marker — no class
+          at '*/5 * * * *', TestSchedulingTick, n: 1        # recurring anchored to the marker
+        end
+      end
+
+      expect(host::Schedules.constants).to be_empty
+
+      sch = Sidereal.scheduler.schedules.first
+      expect(sch.steps[0].klass).to be_nil
+      expect(sch.steps[0].at).to eq(Time.parse('2026-05-04T10:00:00'))
+      expect(sch.steps[1].klass).to eq(TestSchedulingTick)
+      expect(sch.steps[1].from).to eq(Time.parse('2026-05-04T10:00:00'))
+    end
+  end
+
+  describe 'validation' do
+    it 'raises if the schedule block has no at calls' do
+      expect {
+        make_test_host(:HostA) do
+          schedule 'Empty' do
+            # no at(...) calls
+          end
+        end
+      }.to raise_error(ArgumentError, /must declare at least one at/)
+    end
+
+    it 'raises if the multi-step block takes arguments (must use the inner DSL)' do
+      expect {
+        make_test_host(:HostB) do
+          schedule 'Bad' do |_cmd|
+          end
+        end
+      }.to raise_error(ArgumentError, /block must take no arguments/)
+    end
+
+    it 'raises if the schedule name is nil or empty' do
+      expect {
+        make_test_host(:HostC) do
+          schedule '' do
+            at 'every minute', TestSchedulingTick, n: 1
+          end
+        end
+      }.to raise_error(ArgumentError, /name is required/)
+    end
+
+    it 'survives a schedule name that starts with a digit (Sched prefix keeps the constant valid)' do
+      host = make_test_host(:HostF) do
+        schedule '5 minute' do
+          at '*/5 * * * *' do |_cmd| end
+        end
+      end
+
+      expect(host::Schedules.const_defined?(:Sched5Minute0Step0, false)).to be true
+    end
+  end
+end

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Sidereal::Utils do
+  describe '.camel_case' do
+    it 'capitalises each word and joins them' do
+      expect(described_class.camel_case('clock tick')).to eq('ClockTick')
+    end
+
+    it 'splits on any non-alphanumeric run' do
+      expect(described_class.camel_case('flash-sale_campaign')).to eq('FlashSaleCampaign')
+      expect(described_class.camel_case('one  two   three')).to eq('OneTwoThree')
+    end
+
+    it 'preserves digits as-is (callers wanting a valid Ruby constant must add their own letter prefix)' do
+      expect(described_class.camel_case('5 minute')).to eq('5Minute')
+    end
+
+    it 'handles a single word' do
+      expect(described_class.camel_case('hello')).to eq('Hello')
+    end
+
+    it 'returns an empty string for an empty input' do
+      expect(described_class.camel_case('')).to eq('')
+    end
+  end
+
+  describe '.snake_case' do
+    it 'converts a CamelCase string with namespace' do
+      expect(described_class.snake_case('ChatApp::Commander')).to eq('chat_app_commander')
+    end
+
+    it 'inserts underscores at acronym boundaries' do
+      expect(described_class.snake_case('HTTPServer')).to eq('http_server')
+      expect(described_class.snake_case('XMLParser')).to eq('xml_parser')
+    end
+
+    it 'collapses any non-alphanumeric run into a single underscore' do
+      expect(described_class.snake_case('foo-bar baz')).to eq('foo_bar_baz')
+    end
+
+    it 'trims leading and trailing underscores' do
+      expect(described_class.snake_case('__hello__')).to eq('hello')
+    end
+
+    it 'is idempotent for an already snake_case string' do
+      expect(described_class.snake_case('already_snake')).to eq('already_snake')
+    end
+  end
+end


### PR DESCRIPTION
## Working with time

Two complementary scheduling APIs, built on a small leader-election layer that other modules (e.g. `Pubsub::Unix`) can also share.

### Dynamically scheduled commands

Chain `.at(value)` or `.in(value)` (aliases) on a `dispatch` call to defer processing until a future time. Three accepted forms:

| Form                | Example                       | Resolution                                              |
| ------------------- | ----------------------------- | ------------------------------------------------------- |
| `Time` / `DateTime` | `.at(Time.now + 86400)`       | Absolute target.                                        |
| `Integer`           | `.in(3600)`                   | Seconds added to `Time.now`.                            |
| Duration `String`   | `.at('5m')`, `.in('PT1H30M')` | Parsed via `Fugit.parse_duration`, added to `Time.now`. |

```ruby
command PlaceOrder do |cmd|
  ORDERS[cmd.id] = cmd.payload.to_h

  dispatch(SendReminder, order_id: cmd.id).in(3600)
  dispatch(NudgeUser,    order_id: cmd.id).in('30m')
  dispatch(ExpireOrder,  order_id: cmd.id).at(Time.now + 86400)
  dispatch(SendDigest,   order_id: cmd.id).in('PT1H')
end
```

Resolved targets earlier than the message's `created_at` raise `Sidereal::PastMessageDateError`. Honouring of future-dated messages depends on the store: `Store::FileSystem` writes them to a `scheduled/` directory and promotes them when due; `Store::Memory` ignores `created_at` and delivers immediately.

### Fixed schedules — cron-style sequences

`App.schedule` registers a sequence of moments where commands fire. The Scheduler is a leader-only fiber that, on each tick, appends commands to the same store the rest of the app uses — so handlers run on the worker pool with the standard retry / dead-letter machinery.

Single-step shorthand:

```ruby
class MyApp < Sidereal::App
  schedule 'Daily cleanup', '5 0 * * *' do |cmd|
    # Runs every day at 00:05.
    # cmd is auto-generated as MyApp::Commander::Schedules::SchedDailyCleanup0Step0
    dispatch SweepStaleOrders, older_than: '1d'
  end
end
```

Schedule handlers are just command handlers under the hood, so they can also do stuff directly instead of dispatching a new command.

```ruby
schedule 'Daily cleanup', '5 0 * * *' do |cmd|
   Cache.purge_all!
end
```

Multi-step DSL — each `at` call appends a step:

```ruby
schedule 'Flash sale campaign' do
  at '2026-05-10T10:00:00' do |cmd|       # fires once
    dispatch OpenSale, sale_id: 'flash-2026'
  end

  at 'every day at 9am' do |cmd|          # recurring, until next concrete step
    dispatch SendDailyReminders
  end

  at '10d' do |cmd|                       # 10 days after the OPENING step,
    dispatch CloseSale                    # also closes the recurring window
  end
end
```

Step expression accepts anything Fugit parses plus stdlib \`Time\` / \`DateTime\` instances:

| Kind                 | Example                         | Behaviour                                          |
| -------------------- | ------------------------------- | -------------------------------------------------- |
| Specific datetime    | \`'2026-12-31T10:00:00'\`         | Fires once at that instant.                        |
| \`Time\` instance      | \`Time.now + 60\`                 | Fires once (coerced internally).                   |
| Cron (5- or 6-field) | \`'5 0 * * *'\`, \`'*/5 * * * *'\`  | Recurring at every cron match.                     |
| Natural language     | \`'every 3 seconds'\`             | Recurring.                                         |
| Duration             | \`'10d'\`, \`'1h30m'\`, \`'P12Y12M'\` | Fires once at *previous concrete time + duration*. |

Validation rules at registration: no time travel between specific steps; no back-to-back recurring steps; durations resolve against the *last concrete* step (skipping intervening recurring steps); a trailing recurring step is open-ended.

Bound-only marker steps (no block, no class) anchor the timeline without dispatching — useful as a starting boundary for a recurring step, or a closing boundary:

```ruby
schedule 'Office hours' do
  at '2026-05-10T09:00:00'                # marker — opens the window

  at 'every 5 minutes' do |cmd|
    dispatch HealthCheck
  end

  at '2026-05-10T17:00:00'                # marker — closes the recurring
end
```

Explicit command classes can be passed instead of a block to skip auto-generation:

```ruby
schedule 'Flash sale' do
  at '2026-05-10T10:00:00', StartCampaign

  at 'every day at 9am',    SendEmails, sender: 'acme@company.org'

  at '10d',                 EndCampaign
end
```

The Scheduler stamps \`metadata: { producer:, schedule_name: }\` on every dispatch — both keys propagate downstream via \`Message#correlate\`.

### Leader election

Cron firing must run on at most one process per host. New \`Sidereal::Elector\` interface:

- `Elector::AlwaysLeader` — default, single-process apps.
- `Elector::FileSystem(lock_path:)` — flock-based, multi-process single-host (matches `Store::FileSystem` and `Pubsub::Unix` in scope).

`Pubsub::Unix` now delegates its broker election to the injected elector instead of holding its own flock — so the broker process and the schedule-firing process can be the same process (one shared elector across both).

### Other additions

- `Sidereal::Scheduling` mixin extracted from Commander so any class exposing `.command(klass, &block)` can host schedules.
- `Sidereal::Utils.camel_case` / `.snake_case` extracted from Scheduling.
- `Sidereal::System::TriggerSchedule` / `EnterSchedule` / `ExitSchedule` removed — schedules now generate their own per-step command classes under `<HostCommander>::Schedules`.

## Why

- Sidereal apps need cron-style triggers for routine work (digest emails, billing rollups, automated API submissions, etc). Bolting on whenever-style cron jobs forfeits the framework's correlation, retry, and dead-lettering.
- A flat step sequence composes better than fixed enter/run/exit roles for real-world workflows ("start, then poll for an hour, then summarise next morning"), and reads honestly as a timeline.
- Multi-process leader election was already hidden inside `Pubsub::Unix`. Lifting it into a reusable `Elector` interface lets the Scheduler share the same election (one leader per host runs both the broker and the cron) and makes future Redis / DB-advisory-lock backends a small addition.

## How

- New files: `lib/sidereal/elector.rb`, `lib/sidereal/elector/file_system.rb`, `lib/sidereal/scheduler.rb`, `lib/sidereal/scheduling.rb`, `lib/sidereal/utils.rb`.
- `Sidereal.scheduler` / `Sidereal.elector` config slots and per-Service wiring in `Falcon::Environment`.
- `Pubsub::Unix` refactored to take an injected `elector:`; old internal flock dropped.
- `Sidereal::Message#at` now branches on `Time` / `Integer` / `String` (delegated to `Fugit.parse_duration`).
- `fugit` added to gem dependencies.
- Specs split: `spec/scheduling_spec.rb` covers DSL behaviour against a minimal stand-in host (no Commander), `spec/commander_spec.rb` keeps a tiny "is included + registers correctly" check, `spec/scheduler_spec.rb` covers the lower-level Scheduler.
