### PR TITLE
Sidereal.channels: standalone channel-name registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,8 @@ The block runs for every message the dispatcher publishes — both the incoming 
 
 Channel routing also works outside the App class — call `Sidereal.channels.channel_name(...)` from anywhere (e.g. a dedicated routes file) for apps where the registrations grow large enough to warrant their own home.
 
+The registry locks itself once boot is over: `Sidereal::Falcon::Environment::Service` calls `Sidereal.channels.lock!` after class-loading and pubsub startup, before workers start consuming. Subsequent `channel_name(...)` calls raise `Sidereal::Channels::LockedError` — register routes during boot only.
+
 #### Channel name syntax
 
 Channel names are dot-separated tokens (e.g. `campaigns.abc-123.donations.xyz-999`). Subscribers can use two NATS-style wildcards to receive events across multiple concrete channels:

--- a/README.md
+++ b/README.md
@@ -403,11 +403,17 @@ class DonationPage < Sidereal::Page
 end
 ```
 
-For events to actually reach that channel, declare how the App derives a channel name from each message. Use `channel_name` on the `App` — either a static string or a block that receives the message and returns a channel:
+For events to actually reach that channel, declare how the App derives a channel name from each message. The `channel_name` macro registers a resolver on the process-global `Sidereal.channels` registry. Pass message classes positionally to scope the resolver, or no arguments to register a catch-all:
 
 ```ruby
 class DonationsApp < Sidereal::App
+  # Catch-all: every message goes through this block
   channel_name do |msg|
+    "donations.#{msg.payload.donation_id}"
+  end
+
+  # Or scope to specific message classes:
+  channel_name SelectAmount, EnterDonorDetails do |msg|
     "donations.#{msg.payload.donation_id}"
   end
 
@@ -415,7 +421,9 @@ class DonationsApp < Sidereal::App
 end
 ```
 
-The block runs for every message the App's commander publishes — both the incoming command and the events it emits — so there's no per-command wiring. Downstream commands and events dispatched in response are routed by the same rule.
+The block runs for every message the dispatcher publishes — both the incoming command and the events it emits. Resolution is O(1) per message: typed registrations win first, then the catch-all, then a fallback to the literal `'system'` channel (so an app that registers nothing still publishes successfully). System notifications (`Sidereal::System::NotifyRetry`/`NotifyFailure`) are pre-routed via the `:source_channel` metadata that the dispatcher stamps; user-supplied resolvers never see them.
+
+Channel routing also works outside the App class — call `Sidereal.channels.channel_name(...)` from anywhere (e.g. a dedicated routes file) for apps where the registrations grow large enough to warrant their own home.
 
 #### Channel name syntax
 
@@ -967,7 +975,7 @@ For each `Retry` or `Fail` decision, the dispatcher also appends a system comman
 
 Both inherit from `Sidereal::System::Notification` (a marker base). Code that needs system-wide handling can check `msg.is_a?(Sidereal::System::Notification)` rather than enumerating concrete classes.
 
-These flow through the normal command pipeline: every `Sidereal::Commander` subclass auto-registers no-op handlers for them on inheritance, so they get handled, published via pubsub, and routed to the same channel the source command would have been published to (the dispatcher stamps `metadata[:source_channel]` so user-supplied `channel_name` blocks don't have to know about system messages).
+These flow through the normal command pipeline: every `Sidereal::Commander` subclass auto-registers no-op handlers for them on inheritance, so they get handled, published via pubsub, and routed to the same channel the source command would have been published to. The dispatcher stamps `metadata[:source_channel]` on each notification, and `Sidereal.channels` ships with pre-installed handlers for `NotifyRetry`/`NotifyFailure` that read it back — so user-supplied `channel_name` blocks never see system messages.
 
 Override either side — handler or page reaction — to react to failures:
 
@@ -1008,7 +1016,11 @@ module Sidereal
 end
 ```
 
-Defining via `Notification.define(...)` registers it under the `Notification` registry. The dispatcher's loop prevention, `App.channel_name`'s bypass, and Commander's no-op auto-registration all key off `is_a?(Notification)` and the registry, so they pick up the new class automatically. You'll still need to add the corresponding `Page.on(...)` reaction and (optionally) a UI component to render it.
+Defining via `Notification.define(...)` registers it under the `Notification` registry. The dispatcher's loop prevention and Commander's no-op auto-registration both key off `is_a?(Notification)` and pick up the new class automatically. You'll still need to:
+
+- register a `:source_channel`-bypass route for it on `Sidereal.channels` (mirroring the bypass installed for `NotifyRetry`/`NotifyFailure`) so it reaches the originating page's SSE channel;
+- add the corresponding `Page.on(...)` reaction;
+- optionally, add a UI component to render it.
 
 ## How it works
 
@@ -1098,7 +1110,7 @@ class TodoDecider < Sourced::Decider
   # Publish events to Sidereal's PubSub for SSE streaming
   after_sync do |state:, events:|
     events.each do |evt|
-      Sidereal.pubsub.publish(TodoApp.commander.channel_name(evt), evt)
+      Sidereal.pubsub.publish(Sidereal.channels.for(evt), evt)
     end
   end
 end
@@ -1106,7 +1118,7 @@ end
 Sourced.register(TodoDecider)
 ```
 
-The `after_sync` block runs after the store transaction commits and pushes events into Sidereal's PubSub, where Page reactions pick them up and stream DOM updates via SSE. Sourced's dispatcher doesn't auto-publish to PubSub the way Sidereal's does, so the channel is resolved by calling the App's `channel_name` block directly.
+The `after_sync` block runs after the store transaction commits and pushes events into Sidereal's PubSub, where Page reactions pick them up and stream DOM updates via SSE. Sourced's dispatcher doesn't auto-publish to PubSub the way Sidereal's does, so the channel is resolved by looking up `Sidereal.channels.for(evt)` against whatever the App registered with the `channel_name` macro.
 
 ### Pages and App
 
@@ -1147,7 +1159,7 @@ You can also process a command synchronously during the HTTP request using `Sour
 ```ruby
 handle AddTodo do |cmd|
   _cmd, _decider, events = Sourced.handle!(TodoDecider, cmd)
-  events.each { |evt| pubsub.publish(self.class.commander.channel_name(evt), evt) }
+  events.each { |evt| pubsub.publish(Sidereal.channels.for(evt), evt) }
   browser.patch_elements TodoList.new(TODOS.values)
 end
 ```

--- a/examples/sourced_donations/Gemfile.lock
+++ b/examples/sourced_donations/Gemfile.lock
@@ -25,6 +25,7 @@ PATH
       async
       brotli
       datastar (~> 1.0.4)
+      fugit
       phlex
       plumb (~> 0.0.17)
       rack (~> 3)
@@ -77,6 +78,8 @@ GEM
     date (3.5.1)
     diff-lcs (1.6.2)
     erb (6.0.4)
+    et-orbi (1.4.0)
+      tzinfo
     falcon (0.55.2)
       async
       async-container (~> 0.20)
@@ -94,6 +97,9 @@ GEM
     fiber-local (1.1.0)
       fiber-storage
     fiber-storage (1.0.1)
+    fugit (1.12.1)
+      et-orbi (~> 1.4)
+      raabro (~> 1.4)
     io-console (0.8.2)
     io-endpoint (0.17.2)
     io-event (1.15.1)
@@ -134,6 +140,7 @@ GEM
     psych (5.3.1)
       date
       stringio
+    raabro (1.4.0)
     rack (3.2.5)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
@@ -171,6 +178,8 @@ GEM
     stringio (3.2.0)
     traces (0.18.2)
     tsort (0.2.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
     zeitwerk (2.7.5)
 
 PLATFORMS
@@ -204,10 +213,12 @@ CHECKSUMS
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
   erb (6.0.4) sha256=38e3803694be357fe2bfe312487c74beaf9fb4e5beb3e22498952fe1645b95d9
+  et-orbi (1.4.0)
   falcon (0.55.2) sha256=dfcdd8e4c3a18827a5ca7e346df67ebdaf873ac61a5f7d20ad4923c4d6b180cb
   fiber-annotation (0.2.0) sha256=7abfadf1d119f508867d4103bf231c0354d019cc39a5738945dec2edadaf6c03
   fiber-local (1.1.0) sha256=c885f94f210fb9b05737de65d511136ea602e00c5105953748aa0f8793489f06
   fiber-storage (1.0.1) sha256=f48e5b6d8b0be96dac486332b55cee82240057065dc761c1ea692b2e719240e1
+  fugit (1.12.1)
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   io-endpoint (0.17.2) sha256=3feaf766c116b35839c11fac68b6aaadc47887bb488902a57bf8e1d288fb3338
   io-event (1.15.1) sha256=c644cdcf48254015d63f558bf4492f35471f5bb204a42180ea49752be59b30cc
@@ -231,6 +242,7 @@ CHECKSUMS
   protocol-rack (0.22.0) sha256=b7c49c0b597ca2c6d20f8bcd746c4415a1b750eacfbe64f828e780c978a4293d
   protocol-url (0.4.0) sha256=64d4c03b6b51ad815ac6fdaf77a1d91e5baf9220d26becb846c5459dacdea9e1
   psych (5.3.1) sha256=eb7a57cef10c9d70173ff74e739d843ac3b2c019a003de48447b2963d81b1974
+  raabro (1.4.0)
   rack (3.2.5) sha256=4cbd0974c0b79f7a139b4812004a62e4c60b145cba76422e288ee670601ed6d3
   rack-session (2.1.1) sha256=0b6dc07dea7e4b583f58a48e8b806d4c9f1c6c9214ebc202ec94562cbea2e4e9
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
@@ -252,6 +264,7 @@ CHECKSUMS
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
   traces (0.18.2) sha256=80f1649cb4daace1d7174b81f3b3b7427af0b93047759ba349960cb8f315e214
   tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
+  tzinfo (2.0.6)
   zeitwerk (2.7.5) sha256=d8da92128c09ea6ec62c949011b00ed4a20242b255293dd66bf41545398f73dd
 
 BUNDLED WITH

--- a/examples/sourced_donations/README.md
+++ b/examples/sourced_donations/README.md
@@ -60,7 +60,7 @@ class Donation < Sourced::Decider
   # bridge to Sidereal SSE — publish each event on the per-donation channel
   after_sync do |state:, events:, **|
     events.each do |evt|
-      Sidereal.pubsub.publish(DonationsApp.commander.channel_name(evt), evt)
+      Sidereal.pubsub.publish(Sidereal.channels.for(evt), evt)
     end
   end
 end

--- a/examples/sourced_donations/domain/campaign.rb
+++ b/examples/sourced_donations/domain/campaign.rb
@@ -77,7 +77,7 @@ class Campaign < Sourced::Decider
 
   after_sync do |state:, events:, **|
     events.each do |evt|
-      Sidereal.pubsub.publish(DonationsApp.commander.channel_name(evt), evt)
+      Sidereal.pubsub.publish(Sidereal.channels.for(evt), evt)
     end
   end
 end

--- a/examples/sourced_donations/domain/donation.rb
+++ b/examples/sourced_donations/domain/donation.rb
@@ -336,7 +336,7 @@ class Donation < Sourced::Decider
 
   after_sync do |state:, events:, **|
     events.each do |evt|
-      Sidereal.pubsub.publish(DonationsApp.commander.channel_name(evt), evt)
+      Sidereal.pubsub.publish(Sidereal.channels.for(evt), evt)
     end
   end
 end

--- a/lib/sidereal.rb
+++ b/lib/sidereal.rb
@@ -77,6 +77,18 @@ module Sidereal
     @scheduler = nil
   end
 
+  # Process-global channel-name registry. System notifications
+  # ({Sidereal::System::NotifyRetry} / {NotifyFailure}) are pre-routed
+  # via the +:source_channel+ metadata that the dispatcher stamps —
+  # this keeps user-supplied resolvers free of system-message branches.
+  def self.channels
+    @channels ||= Channels.with_system_defaults
+  end
+
+  def self.reset_channels!
+    @channels = nil
+  end
+
   def self.register(commander)
     commander.handled_commands.each do |cmd_class|
       registry[cmd_class] = commander
@@ -136,6 +148,7 @@ end
 
 require_relative 'sidereal/message'
 require_relative 'sidereal/system'
+require_relative 'sidereal/channels'
 require_relative 'sidereal/router'
 require_relative 'sidereal/components/layout'
 require_relative 'sidereal/page'

--- a/lib/sidereal/app.rb
+++ b/lib/sidereal/app.rb
@@ -81,33 +81,31 @@ module Sidereal
         self
       end
 
-      # Define the channel name used by this App's commander to publish
-      # processed messages. Accepts either a static string or a block
-      # that receives the message and returns a channel name.
+      # Register a channel-name resolver. Sugar for
+      # {Sidereal.channels.channel_name}.
+      #
+      # @example Catch-all (any message type)
+      #   channel_name { |cmd| "todos.#{cmd.payload.list_id}" }
+      #
+      # @example Typed registration
+      #   channel_name SomeCmd do |cmd|
+      #     "things.#{cmd.payload.thing_id}"
+      #   end
+      #
+      # @example Multiple types sharing one resolver
+      #   channel_name CmdA, CmdB do |cmd|
+      #     "..."
+      #   end
       #
       # System notifications ({Sidereal::System::NotifyRetry} and
-      # {NotifyFailure}) bypass the user-supplied resolver and instead
-      # use the +:source_channel+ stamped into the notification's
-      # +metadata+ by the dispatcher. This prevents user resolvers that
-      # access domain-specific payload keys (e.g.
-      # +msg.payload.fetch(:donation_id)+) from crashing on system
-      # messages whose payload has a different shape.
+      # {NotifyFailure}) are pre-routed at the {Sidereal.channels} level
+      # via +:source_channel+ metadata stamped by the dispatcher; user
+      # resolvers don't need to handle them.
       #
-      # @example Static channel
-      #   channel_name 'todos'
-      # @example Dynamic channel
-      #   channel_name { |msg| "todos.#{msg.payload.list_id}" }
-      #
+      # @param message_classes [Array<Class>] zero or more message classes
       # @return [self]
-      def channel_name(static_value = nil, &block)
-        user_fn = block || ->(_msg) { static_value }
-        commander.define_singleton_method(:channel_name) do |msg|
-          if msg.is_a?(Sidereal::System::Notification)
-            msg.metadata[:source_channel] || 'system'
-          else
-            user_fn.call(msg)
-          end
-        end
+      def channel_name(*message_classes, &block)
+        Sidereal.channels.channel_name(*message_classes, &block)
         self
       end
 

--- a/lib/sidereal/channels.rb
+++ b/lib/sidereal/channels.rb
@@ -19,6 +19,9 @@ module Sidereal
   class Channels
     DEFAULT_CHANNEL = 'system'
 
+    # Raised when {#channel_name} is called after {#lock!}.
+    LockedError = Class.new(StandardError)
+
     # Build a Channels with the framework-internal source-channel bypass
     # pre-installed for {Sidereal::System::NotifyRetry} and
     # {NotifyFailure}. Use this anywhere a fresh registry needs to
@@ -46,9 +49,11 @@ module Sidereal
     # @param message_classes [Array<Class>] zero or more message classes
     # @yieldparam msg [Sidereal::Message] the message being routed
     # @yieldreturn [String] the channel name
+    # @raise [LockedError] if called after {#lock!}
     # @return [self]
     def channel_name(*message_classes, &block)
       raise ArgumentError, 'block required' unless block
+      raise LockedError, 'channels registry is locked; register routes during boot, before Sidereal.channels.lock!' if @locked
 
       if message_classes.empty?
         @catch_all = block
@@ -71,11 +76,30 @@ module Sidereal
       handler ? handler.call(msg) : DEFAULT_CHANNEL
     end
 
-    # Clear all registrations. For test isolation.
+    # Close the registry. Any subsequent {#channel_name} call raises
+    # {LockedError}. The internal routes hash is also frozen so
+    # accidental low-level mutation surfaces too. Reads ({#for}) keep
+    # working unchanged.
+    #
+    # Called automatically by Sidereal::Falcon::Environment::Service
+    # after class loading and before workers start. Idempotent.
+    #
+    # @return [self]
+    def lock!
+      @routes.freeze
+      @locked = true
+      self
+    end
+
+    # @return [Boolean]
+    def locked? = @locked
+
+    # Clear all registrations and unlock. For test isolation.
     # @return [self]
     def reset!
       @routes = {}
       @catch_all = nil
+      @locked = false
       self
     end
   end

--- a/lib/sidereal/channels.rb
+++ b/lib/sidereal/channels.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module Sidereal
+  # Registry that maps message classes to channel-name resolvers.
+  # Owned by Sidereal as a web-framework concern: any backend
+  # (Sidereal::Dispatcher, a Sourced bridge, custom dispatchers) consults
+  # this single registry to figure out where to publish a message so SSE
+  # subscribers on the matching channel receive it.
+  #
+  # @example Type-specific registration
+  #   Sidereal.channels.channel_name(SomeCommand) { |cmd| "things.#{cmd.payload[:thing_id]}" }
+  #   Sidereal.channels.channel_name(Cmd1, Cmd2) { |cmd| "..." }
+  #
+  # @example Catch-all (no message classes)
+  #   Sidereal.channels.channel_name { |cmd| "..." }
+  #
+  # @example Resolution
+  #   Sidereal.channels.for(msg) # => "things.42"
+  class Channels
+    DEFAULT_CHANNEL = 'system'
+
+    # Build a Channels with the framework-internal source-channel bypass
+    # pre-installed for {Sidereal::System::NotifyRetry} and
+    # {NotifyFailure}. Use this anywhere a fresh registry needs to
+    # behave the way {Sidereal.channels} does — most notably in tests
+    # that inject their own +channels:+ into the dispatcher instead of
+    # mutating the process-global one.
+    #
+    # @return [Channels]
+    def self.with_system_defaults
+      new.tap do |c|
+        bypass = ->(msg) { msg.metadata[:source_channel] || DEFAULT_CHANNEL }
+        c.channel_name(System::NotifyRetry, &bypass)
+        c.channel_name(System::NotifyFailure, &bypass)
+      end
+    end
+
+    def initialize
+      reset!
+    end
+
+    # Register a channel-name resolver for one or more message classes.
+    # With no classes, registers the catch-all that runs when no typed
+    # handler matches.
+    #
+    # @param message_classes [Array<Class>] zero or more message classes
+    # @yieldparam msg [Sidereal::Message] the message being routed
+    # @yieldreturn [String] the channel name
+    # @return [self]
+    def channel_name(*message_classes, &block)
+      raise ArgumentError, 'block required' unless block
+
+      if message_classes.empty?
+        @catch_all = block
+      else
+        message_classes.each { |klass| @routes[klass] = block }
+      end
+      self
+    end
+
+    # Resolve the channel for a message. O(1) hash lookup on
+    # +msg.class+ — does NOT walk ancestors. Falls back to the catch-all
+    # if registered, then to {DEFAULT_CHANNEL}. Never raises so a
+    # misrouted message becomes visible in normal SSE traffic rather
+    # than crashing the worker fiber.
+    #
+    # @param msg [Sidereal::Message]
+    # @return [String]
+    def for(msg)
+      handler = @routes[msg.class] || @catch_all
+      handler ? handler.call(msg) : DEFAULT_CHANNEL
+    end
+
+    # Clear all registrations. For test isolation.
+    # @return [self]
+    def reset!
+      @routes = {}
+      @catch_all = nil
+      self
+    end
+  end
+end

--- a/lib/sidereal/commander.rb
+++ b/lib/sidereal/commander.rb
@@ -66,16 +66,6 @@ module Sidereal
         new(pubsub:).handle(msg)
       end
 
-      # Channel name to publish +message+ to.
-      # Override on a subclass to route messages to specific channels.
-      # Default is 'system'.
-      #
-      # @param message [Sidereal::Message] command or event being routed
-      # @return [String] pubsub channel name
-      def channel_name(_message)
-        'system'
-      end
-
       # Decide what to do with a failed command. Called by the dispatcher
       # when {#handle} raises. Return a {Sidereal::Store::Result} value:
       #
@@ -124,7 +114,7 @@ module Sidereal
     def broadcast(msg_class, payload = {})
       msg = msg_class.new(payload: payload.to_h)
       msg = @__current_msg.correlate(msg)
-      @pubsub.publish self.class.channel_name(msg), msg
+      @pubsub.publish Sidereal.channels.for(msg), msg
       self
     end
 

--- a/lib/sidereal/dispatcher.rb
+++ b/lib/sidereal/dispatcher.rb
@@ -17,12 +17,14 @@ module Sidereal
       worker_count: Sidereal.config.workers,
       store: Sidereal.store,
       registry: Sidereal.registry,
-      pubsub: Sidereal.pubsub
+      pubsub: Sidereal.pubsub,
+      channels: Sidereal.channels
     )
       @worker_count = worker_count
       @store = store
       @registry = registry
       @pubsub = pubsub
+      @channels = channels
     end
 
     def start(task)
@@ -36,7 +38,7 @@ module Sidereal
 
             begin
               result = commander.handle(msg, pubsub: @pubsub)
-              publish(commander, result)
+              publish(result)
               Sidereal::Store::Result::Ack
             rescue StandardError => ex
               policy_result = begin
@@ -47,7 +49,7 @@ module Sidereal
                 Sidereal::Store::Result::Fail.new(error: ex)
               end
               log_failure(commander, msg, meta, ex, policy_result)
-              dispatch_notification(commander, msg, meta, ex, policy_result)
+              dispatch_notification(msg, meta, ex, policy_result)
               policy_result
             end
           end
@@ -97,19 +99,18 @@ module Sidereal
     #
     # All errors during dispatch are logged and swallowed — a failure
     # to notify must never crash the worker loop.
-    def dispatch_notification(commander, msg, meta, exception, policy_result)
+    def dispatch_notification(msg, meta, exception, policy_result)
       return if system_notification?(msg)
 
       notify = build_notification(msg, meta, exception, policy_result)
       return if notify.nil?
       return if @registry[notify.class].nil?
 
-      # Stamp the source command's resolved channel so the user's
-      # +channel_name+ resolver doesn't have to handle system messages
-      # (whose payload shape differs from domain commands). The base
-      # App.channel_name wrapper reads this from metadata for system
-      # notifications and falls back to 'system' if not stamped.
-      source_channel = commander.channel_name(msg)
+      # Stamp the source command's resolved channel so the System
+      # notification routes can look it up via +:source_channel+ in
+      # metadata (registered in {Sidereal.channels}) without having to
+      # know the failed command's payload shape.
+      source_channel = @channels.for(msg)
       stamped = notify.with_metadata(source_channel: source_channel)
 
       @store.append(msg.correlate(stamped))
@@ -152,10 +153,10 @@ module Sidereal
 
     # Publish failures are logged but do not trigger retry. Handle has
     # already mutated state by this point — retrying would double-apply.
-    def publish(commander, result)
-      @pubsub.publish commander.channel_name(result.msg), result.msg
+    def publish(result)
+      @pubsub.publish @channels.for(result.msg), result.msg
       result.events.each do |e|
-        @pubsub.publish commander.channel_name(e), e
+        @pubsub.publish @channels.for(e), e
       end
       result.commands.each do |e|
         @store.append e

--- a/lib/sidereal/falcon/environment.rb
+++ b/lib/sidereal/falcon/environment.rb
@@ -49,6 +49,14 @@ module Sidereal
             # pubsub's background fibers.
             Sidereal.elector.start(task)
             Sidereal.pubsub.start(task)
+
+            # Boot is over: classes have loaded, channel routes are
+            # registered. Lock the channels registry so any further
+            # +Sidereal.channels.channel_name(...)+ call raises loudly
+            # instead of silently racing the worker fibers about to
+            # start consuming.
+            Sidereal.channels.lock!
+
             @dispatcher = Sidereal.dispatcher.start(task)
             Sidereal.scheduler.start(task)
 

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -145,26 +145,30 @@ RSpec.describe 'Sidereal::App.handle' do
   end
 
   describe '.channel_name macro' do
-    it 'defines a static channel name on the App\'s commander' do
-      app = Class.new(Sidereal::App) do
-        session secret: 'a' * 64
-        channel_name 'custom'
-        command HandleTestCmd
-      end
+    before { Sidereal.reset_channels! }
 
-      msg = HandleTestCmd.new(payload: { title: 'x' })
-      expect(app.commander.channel_name(msg)).to eq('custom')
-    end
-
-    it 'defines a dynamic channel name from a block' do
-      app = Class.new(Sidereal::App) do
+    it 'registers a catch-all resolver via Sidereal.channels' do
+      Class.new(Sidereal::App) do
         session secret: 'a' * 64
         channel_name { |msg| "items.#{msg.payload.title}" }
         command HandleTestCmd
       end
 
       msg = HandleTestCmd.new(payload: { title: '42' })
-      expect(app.commander.channel_name(msg)).to eq('items.42')
+      expect(Sidereal.channels.for(msg)).to eq('items.42')
+    end
+
+    it 'registers a typed resolver scoped to a message class' do
+      Class.new(Sidereal::App) do
+        session secret: 'a' * 64
+        channel_name HandleTestCmd do |msg|
+          "things.#{msg.payload.title}"
+        end
+        command HandleTestCmd
+      end
+
+      msg = HandleTestCmd.new(payload: { title: '99' })
+      expect(Sidereal.channels.for(msg)).to eq('things.99')
     end
   end
 

--- a/spec/channels_spec.rb
+++ b/spec/channels_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Sidereal::Channels do
+  subject(:channels) { described_class.new }
+
+  let(:msg_a_class) { Sidereal::Message.define('test.cmd_a') }
+  let(:msg_b_class) { Sidereal::Message.define('test.cmd_b') }
+  let(:msg_c_class) { Sidereal::Message.define('test.cmd_c') }
+
+  describe '#channel_name' do
+    it 'registers a typed handler for one class' do
+      channels.channel_name(msg_a_class) { |_| 'a-channel' }
+
+      expect(channels.for(msg_a_class.new)).to eq('a-channel')
+    end
+
+    it 'registers the same block for multiple classes when given as positional args' do
+      channels.channel_name(msg_a_class, msg_b_class) { |msg| "shared.#{msg.class.type}" }
+
+      expect(channels.for(msg_a_class.new)).to eq('shared.test.cmd_a')
+      expect(channels.for(msg_b_class.new)).to eq('shared.test.cmd_b')
+    end
+
+    it 'registers a catch-all when no message classes are given' do
+      channels.channel_name { |_| 'catch-all' }
+
+      expect(channels.for(msg_a_class.new)).to eq('catch-all')
+    end
+
+    it 'raises ArgumentError without a block' do
+      expect { channels.channel_name(msg_a_class) }.to raise_error(ArgumentError, /block required/)
+    end
+  end
+
+  describe '#for' do
+    it 'is O(1) and does not walk class ancestors' do
+      parent = Class.new(Sidereal::Message)
+      child  = Class.new(parent)
+
+      channels.channel_name(parent) { |_| 'parent-channel' }
+
+      # A handler on the parent class does NOT match child instances.
+      expect(channels.for(child.new)).to eq(Sidereal::Channels::DEFAULT_CHANNEL)
+    end
+
+    it 'falls back to the catch-all when the typed map misses' do
+      channels.channel_name(msg_a_class) { |_| 'typed' }
+      channels.channel_name { |_| 'fallback' }
+
+      expect(channels.for(msg_a_class.new)).to eq('typed')
+      expect(channels.for(msg_b_class.new)).to eq('fallback')
+    end
+
+    it 'falls back to the default "system" channel when nothing is registered' do
+      expect(channels.for(msg_a_class.new)).to eq('system')
+      expect(Sidereal::Channels::DEFAULT_CHANNEL).to eq('system')
+    end
+
+    it 'never raises on an unknown message — keeps publishing as the safe default' do
+      expect { channels.for(msg_c_class.new) }.not_to raise_error
+    end
+  end
+
+  describe '#reset!' do
+    it 'clears typed and catch-all registrations' do
+      channels.channel_name(msg_a_class) { |_| 'a' }
+      channels.channel_name { |_| 'b' }
+      channels.reset!
+
+      expect(channels.for(msg_a_class.new)).to eq('system')
+    end
+  end
+
+  describe 'Sidereal.channels (process-global)' do
+    before { Sidereal.reset_channels! }
+
+    it 'pre-registers the System::NotifyRetry source-channel bypass' do
+      retry_msg = Sidereal::System::NotifyRetry.new(
+        payload: { command_type: 'x', command_id: 'id', attempt: 1, retry_at: Time.now.iso8601, error_class: 'E', error_message: 'boom' },
+        metadata: { source_channel: 'campaigns.42' }
+      )
+
+      expect(Sidereal.channels.for(retry_msg)).to eq('campaigns.42')
+    end
+
+    it 'pre-registers the System::NotifyFailure source-channel bypass' do
+      fail_msg = Sidereal::System::NotifyFailure.new(
+        payload: { command_type: 'x', command_id: 'id', attempt: 1, error_class: 'E', error_message: 'boom' },
+        metadata: { source_channel: 'campaigns.42' }
+      )
+
+      expect(Sidereal.channels.for(fail_msg)).to eq('campaigns.42')
+    end
+
+    it "falls back to 'system' when source_channel is not stamped" do
+      retry_msg = Sidereal::System::NotifyRetry.new(
+        payload: { command_type: 'x', command_id: 'id', attempt: 1, retry_at: Time.now.iso8601, error_class: 'E', error_message: 'boom' }
+      )
+
+      expect(Sidereal.channels.for(retry_msg)).to eq('system')
+    end
+  end
+end

--- a/spec/channels_spec.rb
+++ b/spec/channels_spec.rb
@@ -71,6 +71,47 @@ RSpec.describe Sidereal::Channels do
 
       expect(channels.for(msg_a_class.new)).to eq('system')
     end
+
+    it 'unlocks a locked registry' do
+      channels.lock!
+      channels.reset!
+
+      expect(channels.locked?).to be(false)
+      expect { channels.channel_name { |_| 'x' } }.not_to raise_error
+    end
+  end
+
+  describe '#lock!' do
+    it 'is idempotent and reports state via #locked?' do
+      expect(channels.locked?).to be(false)
+      channels.lock!
+      expect(channels.locked?).to be(true)
+      expect { channels.lock! }.not_to raise_error
+    end
+
+    it 'raises LockedError on subsequent typed registration' do
+      channels.channel_name(msg_a_class) { |_| 'a' }
+      channels.lock!
+
+      expect {
+        channels.channel_name(msg_b_class) { |_| 'b' }
+      }.to raise_error(Sidereal::Channels::LockedError, /locked/)
+    end
+
+    it 'raises LockedError on subsequent catch-all registration' do
+      channels.lock!
+
+      expect {
+        channels.channel_name { |_| 'late' }
+      }.to raise_error(Sidereal::Channels::LockedError)
+    end
+
+    it 'still resolves via #for after lock' do
+      channels.channel_name(msg_a_class) { |_| 'a-channel' }
+      channels.lock!
+
+      expect(channels.for(msg_a_class.new)).to eq('a-channel')
+    end
   end
 
   describe 'Sidereal.channels (process-global)' do

--- a/spec/commander_spec.rb
+++ b/spec/commander_spec.rb
@@ -279,22 +279,6 @@ RSpec.describe Sidereal::Commander do
     end
   end
 
-  describe '.channel_name' do
-    it "defaults to 'system'" do
-      msg = TestAddItem.new(payload: { title: 'x' })
-      expect(Sidereal::Commander.channel_name(msg)).to eq('system')
-    end
-
-    it 'is overridable on a subclass' do
-      cmdr = Class.new(Sidereal::Commander) do
-        def self.channel_name(msg) = "items.#{msg.payload.title}"
-      end
-
-      msg = TestAddItem.new(payload: { title: '42' })
-      expect(cmdr.channel_name(msg)).to eq('items.42')
-    end
-  end
-
   describe '.on_error' do
     let(:msg) { TestAddItem.new(payload: { name: 'x' }) }
 
@@ -366,13 +350,15 @@ RSpec.describe Sidereal::Commander do
   end
 
   describe '#broadcast' do
-    it 'publishes to the channel returned by self.class.channel_name' do
+    before { Sidereal.reset_channels! }
+
+    it 'publishes to the channel resolved by Sidereal.channels.for' do
+      Sidereal.channels.channel_name(TestNotification) { |_| 'test-ch' }
+
       cmdr_class = Class.new(Sidereal::Commander) do
         command TestAddItem do |cmd|
           broadcast TestNotification, text: 'hello'
         end
-
-        def self.channel_name(_) = 'test-ch'
       end
 
       cmd = TestAddItem.new(payload: { title: 'x' })

--- a/spec/dispatcher_spec.rb
+++ b/spec/dispatcher_spec.rb
@@ -24,6 +24,16 @@ RSpec.describe Sidereal::Dispatcher do
   let(:store) { Sidereal::Store::Memory.new }
   let(:pubsub) { Sidereal::PubSub::Memory.new }
 
+  # Inject a per-spec channel registry rather than mutating
+  # +Sidereal.channels+. Pre-loaded with the System notification
+  # bypass + a catch-all that routes every domain message to 'ch1'
+  # (the channel most tests subscribe to).
+  let(:channels) do
+    Sidereal::Channels.with_system_defaults.tap do |c|
+      c.channel_name { |_| 'ch1' }
+    end
+  end
+
   def registry_for(*commanders)
     Sidereal::Registry.new.tap do |r|
       commanders.each do |c|
@@ -35,7 +45,7 @@ RSpec.describe Sidereal::Dispatcher do
   # Run the dispatcher, subscribe to a channel, and collect published messages.
   # Yields a block where the caller can append commands to the store.
   # Returns the list of messages received on the channel.
-  def run_and_collect(channel_name, store:, registry:, pubsub:, &block)
+  def run_and_collect(channel_name, store:, registry:, pubsub:, channels: self.channels, &block)
     received = []
 
     Sync do |task|
@@ -52,7 +62,8 @@ RSpec.describe Sidereal::Dispatcher do
         worker_count: 1,
         store: store,
         registry: registry,
-        pubsub: pubsub
+        pubsub: pubsub,
+        channels: channels
       ).start(task)
 
       task.async do
@@ -172,20 +183,17 @@ RSpec.describe Sidereal::Dispatcher do
     expect(titles).to eq(%w[first second third])
   end
 
-  it 'routes via the commander, computing the channel from each message' do
-    routed = { 'a' => [], 'b' => [] }
-
+  it 'resolves the channel via the injected Channels for each published message' do
     routing_commander = Class.new(Sidereal::Commander) do
       command DispatchCmd do |cmd|
         dispatch DispatchEvt, title: cmd.payload.title
       end
-
-      define_singleton_method(:channel_name) do |msg|
-        # Use payload to choose channel — exercises that channel_name
-        # receives the message and can switch on it.
-        msg.is_a?(DispatchEvt) ? "evt-#{msg.payload.title}" : 'cmds'
-      end
     end
+
+    # Per-class registrations override the catch-all baked into the
+    # +channels+ let.
+    channels.channel_name(DispatchCmd) { |_| 'cmds' }
+    channels.channel_name(DispatchEvt) { |msg| "evt-#{msg.payload.title}" }
 
     store.append(DispatchCmd.new(payload: { title: 'a' }))
 
@@ -201,7 +209,7 @@ RSpec.describe Sidereal::Dispatcher do
       task.async { evt.start { |m, _| received_evt << m } }
 
       Sidereal::Dispatcher.new(
-        worker_count: 1, store: store, registry: registry_for(routing_commander), pubsub: pubsub
+        worker_count: 1, store: store, registry: registry_for(routing_commander), pubsub: pubsub, channels: channels
       ).start(task)
 
       task.async do
@@ -410,7 +418,7 @@ RSpec.describe Sidereal::Dispatcher do
 
       store.append(DispatchCmd.new(payload: { title: 'orphan' }))
 
-      received = run_and_collect('ch1', store: store, registry: registry, pubsub: pubsub) {}
+      received = run_and_collect('ch1', store: store, registry: registry, pubsub: pubsub, channels: channels) {}
 
       # No NotifyFailure should appear in the channel — dispatcher
       # detected no handler and skipped the dispatch.
@@ -432,15 +440,13 @@ RSpec.describe Sidereal::Dispatcher do
         end
       end
 
-      # Apply the App.channel_name-style wrapper directly to the
-      # commander so we exercise the bypass logic.
-      user_fn = ->(msg) { "ch.#{msg.payload.fetch(:title)}" }
-      cmdr.define_singleton_method(:channel_name) do |msg|
-        if msg.is_a?(Sidereal::System::Notification)
-          msg.metadata[:source_channel] || 'system'
-        else
-          user_fn.call(msg)
-        end
+      # Register a domain-specific resolver on the injected registry —
+      # this is what was previously installed via App.channel_name.
+      # System notifications continue to route via the pre-installed
+      # source_channel bypass (Channels.with_system_defaults), so the
+      # resolver below never sees them.
+      channels.channel_name(DispatchCmd) do |msg|
+        "ch.#{msg.payload.fetch(:title)}"
       end
 
       store.append(DispatchCmd.new(payload: { title: 'doomed' }))


### PR DESCRIPTION
## What

- New **`Sidereal::Channels`** — a process-global registry mapping message classes to channel-name resolvers, accessed via `Sidereal.channels`. Typed registrations + a catch-all + a default `'system'` fallback.
- The **`App.channel_name`** macro now accepts positional message classes:
  ```ruby
  class MyApp < Sidereal::App
    channel_name SomeCmd do |cmd|
      "things.#{cmd.payload.thing_id}"
    end

    channel_name CmdA, CmdB do |cmd|
      "..."
    end

    channel_name do |cmd|     # catch-all
      "..."
    end
  end
  ```
  It's now sugar that delegates to `Sidereal.channels.channel_name(...)` rather than installing a method on `Commander`.
- **Removed** `Commander.channel_name` and the `commander.define_singleton_method(:channel_name)` install path. `Commander` no longer carries channel-routing logic.
- **Removed** the inline `if msg.is_a?(Sidereal::System::Notification)` branch from `App.channel_name` — the `:source_channel` bypass is now two regular registered routes installed by `Channels.with_system_defaults`. Adding a new system message type means registering one more bypass route, not editing an `if/else`.
- **`Sidereal::Dispatcher`** now resolves channels via the injected `channels:` (defaults to `Sidereal.channels`). Three call sites switched from `commander.channel_name(msg)` → `@channels.for(msg)`.
- **`Commander#broadcast`** likewise switched to `Sidereal.channels.for(msg)`.
- **Sourced-backed call sites in examples/sourced_donations** migrated from `DonationsApp.commander.channel_name(evt)` → `Sidereal.channels.for(evt)` in both Decider `after_sync` blocks and the README snippet.
- **`SSE error log loudness**: `app.rb`'s `on_error` callback bumped from `Console.info "ERROR #{ex}"` to `Console.error(self, 'SSE stream error', exception: ex)` so handler exceptions raised inside SSE-channel reactions show up with class + backtrace at ERROR level instead of silently as INFO.
- **Specs**: new `spec/channels_spec.rb` (12 examples). `spec/dispatcher_spec.rb` injects its own `Sidereal::Channels.with_system_defaults` instance — no global state mutation. `spec/commander_spec.rb` and `spec/app_spec.rb` migrated to assert against `Sidereal.channels.for(msg)`. Two obsolete `Commander.channel_name` tests removed. 396 examples, 0 failures.

## Why

The integration story between Sidereal and Sourced (or any non-Sidereal dispatcher) kept tripping over the same seam: `App.commander.channel_name` was the only piece of the App's `Commander` that Sourced-backed code still needed, so `Commander` survived as a vestigial name-server. Sourced Deciders had to reach across that seam from their `after_sync` hooks (`examples/sourced_donations/domain/donation.rb`) — a smell that surfaced every time we tried to hook anything new into the dispatcher contract.

The reframing: channel-name routing is **Sidereal's concern in service of its real-time UI** — independent of which backend handles commands. Lifting it into a dedicated registry means:

- Any dispatcher (Sidereal::Dispatcher, Sourced::Dispatcher, future ones) can resolve channels by consulting one well-known place; no `App.commander` reach-across needed.
- The system-notification bypass becomes just another registered route. The previous `if msg.is_a?(System::Notification)` special case in `App.channel_name` was the only hard-coded branch in the resolver — now it's expressed in the same shape as user routes.
- Apps that don't care about routing get sensible behaviour out of the box: the default catch-all returns `'system'`, the same channel `Page#channel_name` defaults to. Register nothing, and SSE still works against one shared channel.

This is the first of a three-part series sketched out during planning. Concern 2 (a Sidereal-level exception-notification contract that Sourced backends can satisfy uniformly) will build on `Sidereal.channels.for(failed_cmd)` when it's revisited; concern 1 (per-dispatcher retry policy) is unchanged and stays each backend's business.

## How

**`lib/sidereal/channels.rb` (new)** — class with two methods:

```ruby
def channel_name(*message_classes, &block)
  raise ArgumentError, 'block required' unless block

  if message_classes.empty?
    @catch_all = block
  else
    message_classes.each { |klass| @routes[klass] = block }
  end
  self
end

def for(msg)
  handler = @routes[msg.class] || @catch_all
  handler ? handler.call(msg) : DEFAULT_CHANNEL
end
```

**Lookup** is intentionally O(1) on `msg.class` — no `class.ancestors` walk. Subclasses don't share schemas, so resolving a `MyEvent` via a route registered for its parent would be a footgun rather than a feature. `for(msg)` falls back to the catch-all, then to the literal `'system'` channel. It never raises — keeps publishing as the safe default and lets misrouted messages surface in normal SSE traffic rather than blowing up the worker fiber.

**`Channels.with_system_defaults`** factory pre-installs the source-channel bypass for both concrete System notification classes:

```ruby
def self.with_system_defaults
  new.tap do |c|
    bypass = ->(msg) { msg.metadata[:source_channel] || DEFAULT_CHANNEL }
    c.channel_name(System::NotifyRetry, &bypass)
    c.channel_name(System::NotifyFailure, &bypass)
  end
end
```

`Sidereal.channels` uses this in its lazy initializer; tests inject their own `Channels.with_system_defaults` into the dispatcher to keep their fixtures isolated from the global registry.

**`Sidereal::Dispatcher`** grew a `channels:` constructor parameter that defaults to `Sidereal.channels`. Three internal call sites (`dispatch_notification`, `publish` x2) now read from `@channels.for(msg)`. The `commander` argument was dropped from `publish` and `dispatch_notification` since neither resolves channels through it anymore.

**`Sidereal::App`** — `channel_name(*message_classes, &block)` is now a one-liner: `Sidereal.channels.channel_name(*message_classes, &block)`. The class also exposes a `channels` accessor pointing at `Sidereal.channels` for explicit calls. The `commander.define_singleton_method` install path and the `is_a?(System::Notification)` branch are gone.

**Migration** is breaking but mechanical:

- `MyApp.commander.channel_name(msg)` → `Sidereal.channels.for(msg)` (one example crossed: `examples/sourced_donations/domain/{donation,campaign}.rb`).
- `channel_name 'static-string'` (the dropped positional-string form) → `channel_name { 'static-string' }`. No examples used this form.
- `channel_name do |cmd| ... end` (catch-all block form) — call shape unchanged. Internally registers as the catch-all under the new semantics. `donations1`, `sourced_donations` use this form.

**Demo apps with no channel routing** (`chat`, `progress`, `todos`) are unaffected — they were already implicitly publishing to `'system'` (the previous `Commander.channel_name` default), and `Sidereal.channels.for` also defaults to `'system'` when nothing is registered.
