### PR TITLE
Render components with layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,22 @@ handle PlaceOrder do |cmd|
 end
 ```
 
+### Rendering components
+
+The `component` helper renders any object responding to `#call(context:)`, passing the app instance as context. This is how Sidereal pages and layouts are rendered under the hood, and it's available inside any route block defined on an App subclass.
+
+```ruby
+class MyApp < Sidereal::App
+  get '/dashboard' do
+    component DashboardPage.new(current_user)
+  end
+
+  get '/error' do
+    component ErrorPage.new, status: 422
+  end
+end
+```
+
 ## Pages
 
 Pages are reactive [Phlex](https://www.phlex.fun/) components that re-render parts of the UI in response to events via SSE.
@@ -783,22 +799,6 @@ class MyRouter < Sidereal::Router
 
   get '/dashboard' do
     body 'welcome'
-  end
-end
-```
-
-### Rendering components
-
-The `component` helper renders any object responding to `#call(context:)`, passing the router instance as context. This is how Sidereal pages and layouts are rendered under the hood.
-
-```ruby
-class MyRouter < Sidereal::Router
-  get '/dashboard' do
-    component DashboardPage.new(current_user)
-  end
-
-  get '/error' do
-    component ErrorPage.new, status: 422
   end
 end
 ```

--- a/examples/donations1/app.rb
+++ b/examples/donations1/app.rb
@@ -278,7 +278,7 @@ class DonationsApp < Sidereal::App
   end
 
   get '/' do
-    component self.class.layout.new(DonationPage.new)
+    component DonationPage.new
   end
 
   page DonationPage

--- a/examples/sourced_donations/app.rb
+++ b/examples/sourced_donations/app.rb
@@ -32,9 +32,7 @@ class DonationsApp < Sidereal::App
     )
     halt 404, 'Not found' if messages.length < step_int
 
-    component self.class.layout.new(
-      DonationPage.new(donation: state, messages: messages, current_step: step_int)
-    )
+    component DonationPage.new(donation: state, messages: messages, current_step: step_int)
   end
 
   get '/:campaign_id/:donation_id/verify/:token' do |campaign_id:, donation_id:, token:|

--- a/lib/sidereal/app.rb
+++ b/lib/sidereal/app.rb
@@ -42,7 +42,7 @@ module Sidereal
 
       def layout(ly = nil)
         @layout = ly if ly
-        @layout || BasicLayout
+        @layout || Components::BasicLayout
       end
 
       def page(pg, layout: nil, &block)
@@ -61,7 +61,7 @@ module Sidereal
 
         Sidereal::Page.register(page_class)
         get(page_class.path) do
-          component layout.new(page_class.load(params, self))
+          component page_class.load(params, self), layout:
         end
 
         self
@@ -267,13 +267,16 @@ module Sidereal
     #
     # @param cmp [#call] component responding to +#call(context:)+
     # @param status [Integer] HTTP status code (default: 200)
+    # @param layout [Class<Sidereal::Components::Layout>, nil] layout class to wrap +cmp+ in;
+    #   defaults to the app's configured layout. Pass +nil+ to render without a layout.
     #
     # @example
     #   get '/dashboard' do
     #     component DashboardPage.new(current_user)
     #   end
-    def component(cmp, status: 200)
+    def component(cmp, status: 200, layout: self.class.layout)
       self.status status
+      cmp = layout.new(cmp) if layout
       body cmp.call(context: self)
     end
 

--- a/lib/sidereal/app.rb
+++ b/lib/sidereal/app.rb
@@ -260,6 +260,23 @@ module Sidereal
       store.append(cmd)
     end
 
+    # Render a component that responds to +#call(context:)+.
+    #
+    # Calls the component with the app instance as context,
+    # and sets the response body to the return value.
+    #
+    # @param cmp [#call] component responding to +#call(context:)+
+    # @param status [Integer] HTTP status code (default: 200)
+    #
+    # @example
+    #   get '/dashboard' do
+    #     component DashboardPage.new(current_user)
+    #   end
+    def component(cmp, status: 200)
+      self.status status
+      body cmp.call(context: self)
+    end
+
     def params
       @params ||= request.env.fetch('router.params', EMPTY_PARAMS)
     end

--- a/lib/sidereal/app.rb
+++ b/lib/sidereal/app.rb
@@ -265,18 +265,28 @@ module Sidereal
     # Calls the component with the app instance as context,
     # and sets the response body to the return value.
     #
+    # If +cmp+ is a {Sidereal::Page} it is wrapped in the app's layout
+    # (or the +layout:+ override). Any other +#call+-compatible component
+    # is rendered directly — layouts are page-only.
+    #
     # @param cmp [#call] component responding to +#call(context:)+
     # @param status [Integer] HTTP status code (default: 200)
-    # @param layout [Class<Sidereal::Components::Layout>, nil] layout class to wrap +cmp+ in;
-    #   defaults to the app's configured layout. Pass +nil+ to render without a layout.
+    # @param layout [Class<Sidereal::Components::Layout>, nil] layout class to wrap a page in;
+    #   defaults to the app's configured layout. Pass +nil+ to render a page without a layout.
+    #   Ignored when +cmp+ is not a {Sidereal::Page}.
     #
-    # @example
+    # @example Render a page (auto-wrapped in the app's layout)
     #   get '/dashboard' do
     #     component DashboardPage.new(current_user)
     #   end
+    #
+    # @example Render a non-page component directly
+    #   get '/healthz' do
+    #     component HealthCheck.new
+    #   end
     def component(cmp, status: 200, layout: self.class.layout)
       self.status status
-      cmp = layout.new(cmp) if layout
+      cmp = layout.new(cmp) if layout && cmp.is_a?(Sidereal::Page)
       body cmp.call(context: self)
     end
 

--- a/lib/sidereal/components/layout.rb
+++ b/lib/sidereal/components/layout.rb
@@ -6,6 +6,8 @@ module Sidereal
   module Components
     class Layout < BaseComponent
       def initialize(page)
+        raise ArgumentError, "expected Sidereal::Page, but got #{page.inspect}" unless page.is_a?(Sidereal::Page)
+
         @page = page
       end
 

--- a/lib/sidereal/router.rb
+++ b/lib/sidereal/router.rb
@@ -548,23 +548,6 @@ module Sidereal
       throw :halt, response.finish
     end
 
-    # Render a component that responds to +#call(context:)+.
-    #
-    # Calls the component with the router instance as context,
-    # and sets the response body to the return value.
-    #
-    # @param cmp [#call] component responding to +#call(context:)+
-    # @param status [Integer] HTTP status code (default: 200)
-    #
-    # @example
-    #   get '/dashboard' do
-    #     component DashboardPage.new(current_user)
-    #   end
-    def component(cmp, status: 200)
-      self.status status
-      body cmp.call(context: self)
-    end
-
     # Set the HTTP status code on the response.
     #
     # @param st [Integer, Symbol] status code or Rack symbol (e.g. +:ok+, +:not_found+)

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -45,6 +45,44 @@ RSpec.describe 'Sidereal::App.commander' do
   end
 end
 
+RSpec.describe 'Sidereal::App#component' do
+  include Rack::Test::Methods
+
+  let(:component_app) do
+    test_component = Class.new do
+      def call(context:)
+        "hello from component, method:#{context.request.request_method}"
+      end
+    end
+
+    Class.new(Sidereal::App) do
+      get '/with-component' do
+        component test_component.new
+      end
+
+      get '/with-status' do
+        component test_component.new, status: 201
+      end
+    end
+  end
+
+  def app
+    component_app
+  end
+
+  it 'renders the component with the app as context' do
+    get '/with-component'
+    expect(last_response.status).to eq(200)
+    expect(last_response.body).to eq('hello from component, method:GET')
+  end
+
+  it 'accepts a custom status' do
+    get '/with-status'
+    expect(last_response.status).to eq(201)
+    expect(last_response.body).to eq('hello from component, method:GET')
+  end
+end
+
 RSpec.describe 'Sidereal::App.handle' do
   include Rack::Test::Methods
 

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -83,21 +83,22 @@ RSpec.describe 'Sidereal::App#component' do
     expect(last_response.body).to include('<p>hello from component, method:GET</p>')
   end
 
-  it 'raises when the component is not a Sidereal::Page' do
-    not_a_page = Class.new do
+  it 'renders a non-Page component directly, bypassing the layout' do
+    bare_component = Class.new do
       def call(context:)
-        'plain'
+        "bare, method:#{context.request.request_method}"
       end
     end
 
     app_class = Class.new(Sidereal::App) do
       get '/raw' do
-        component not_a_page.new
+        component bare_component.new
       end
     end
 
-    expect { Rack::MockRequest.new(app_class).get('/raw') }
-      .to raise_error(ArgumentError, /expected Sidereal::Page/)
+    response = Rack::MockRequest.new(app_class).get('/raw')
+    expect(response.status).to eq(200)
+    expect(response.body).to eq('bare, method:GET')
   end
 end
 

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -49,19 +49,19 @@ RSpec.describe 'Sidereal::App#component' do
   include Rack::Test::Methods
 
   let(:component_app) do
-    test_component = Class.new do
-      def call(context:)
-        "hello from component, method:#{context.request.request_method}"
+    test_page = Class.new(Sidereal::Page) do
+      view_template do
+        p { "hello from component, method:#{context.request.request_method}" }
       end
     end
 
     Class.new(Sidereal::App) do
       get '/with-component' do
-        component test_component.new
+        component test_page.new
       end
 
       get '/with-status' do
-        component test_component.new, status: 201
+        component test_page.new, status: 201
       end
     end
   end
@@ -70,16 +70,34 @@ RSpec.describe 'Sidereal::App#component' do
     component_app
   end
 
-  it 'renders the component with the app as context' do
+  it 'renders the component wrapped in the app layout, with the app as context' do
     get '/with-component'
     expect(last_response.status).to eq(200)
-    expect(last_response.body).to eq('hello from component, method:GET')
+    expect(last_response.body).to include('<p>hello from component, method:GET</p>')
+    expect(last_response.body).to include('<!doctype html>')
   end
 
   it 'accepts a custom status' do
     get '/with-status'
     expect(last_response.status).to eq(201)
-    expect(last_response.body).to eq('hello from component, method:GET')
+    expect(last_response.body).to include('<p>hello from component, method:GET</p>')
+  end
+
+  it 'raises when the component is not a Sidereal::Page' do
+    not_a_page = Class.new do
+      def call(context:)
+        'plain'
+      end
+    end
+
+    app_class = Class.new(Sidereal::App) do
+      get '/raw' do
+        component not_a_page.new
+      end
+    end
+
+    expect { Rack::MockRequest.new(app_class).get('/raw') }
+      .to raise_error(ArgumentError, /expected Sidereal::Page/)
   end
 end
 

--- a/spec/router_spec.rb
+++ b/spec/router_spec.rb
@@ -323,42 +323,6 @@ RSpec.describe Sidereal::Router do
     end
   end
 
-  describe '#component' do
-    let(:component_router) do
-      test_component = Class.new do
-        def call(context:)
-          "hello from component, method:#{context.request.request_method}"
-        end
-      end
-
-      Class.new(Sidereal::Router) do
-        get '/with-component' do
-          component test_component.new
-        end
-
-        get '/with-status' do
-          component test_component.new, status: 201
-        end
-      end
-    end
-
-    def app
-      component_router
-    end
-
-    it 'renders the component with the router as context' do
-      get '/with-component'
-      expect(last_response.status).to eq(200)
-      expect(last_response.body).to eq('hello from component, method:GET')
-    end
-
-    it 'accepts a custom status' do
-      get '/with-status'
-      expect(last_response.status).to eq(201)
-      expect(last_response.body).to eq('hello from component, method:GET')
-    end
-  end
-
   describe '#session without configuration' do
     it 'raises when sessions are not enabled' do
       # TestRouter has no session configured


### PR DESCRIPTION
Tweak `App#component` to render page components within the app's layout (or take an optional layout class).

```ruby
layout ApplicationLayout

# Renders page within ApplicationLayout above
get '/things' do
  component ThingsPage.new
end

# Renders page within different layout
get '/things' do
  component ThingsPage.new, layout: DifferentLayout
end
```