### PR TITLE
App.commands registers multiple commanders

### DIFF
--- a/lib/sidereal/app.rb
+++ b/lib/sidereal/app.rb
@@ -75,9 +75,36 @@ module Sidereal
         end
       end
 
+      # Register one or more *additional* commanders with the app, beyond
+      # the default inline commander that {.command}/{.schedule} target.
+      # Each commander is wired into the process-global {Sidereal.registry},
+      # which routes commands to commanders by class at dispatch time.
+      #
+      # @example Register an existing commander class
+      #   commands CustomerStateMachine
+      #
+      # @example Register a subclass that extends an existing commander
+      #   commands SomeCommander do
+      #     command Extra do |cmd| ... end
+      #   end
+      #   # SomeCommander is *not* mutated; a subclass inheriting its
+      #   # command registrations (see Commander.inherited) is registered.
+      #
+      # @example Build and register a brand-new anonymous commander
+      #   commands do
+      #     command StartTrial do |cmd| ... end
+      #   end
+      #
+      # @param cmder [Class, nil] an existing commander class, or nil to
+      #   build a fresh one from the block
+      # @return [self]
       def commands(cmder = nil, &block)
-        @commander = cmder if cmder
-        @commander.class_eval(&block) if block_given?
+        if cmder.nil? && block.nil?
+          raise ArgumentError, 'commands requires a commander class or a block'
+        end
+
+        cmder = Class.new(cmder || Commander, &block) if block
+        Sidereal.register(cmder)
         self
       end
 
@@ -110,8 +137,19 @@ module Sidereal
         self
       end
 
-      def command_helpers(...)
-        commands(...)
+      # Add helper methods to the *default* inline commander (the one
+      # {.command}/{.schedule} target). Use for shared private helpers that
+      # command handlers call.
+      #
+      # @example
+      #   command_helpers do
+      #     private def repo = MyRepo.new
+      #   end
+      #
+      # @return [self]
+      def command_helpers(&block)
+        commander.class_eval(&block) if block
+        self
       end
 
       def before_command(&block)

--- a/lib/sidereal/commander.rb
+++ b/lib/sidereal/commander.rb
@@ -14,6 +14,19 @@ module Sidereal
     class << self
       def commander = self
 
+      # Seed a subclass's command registry from its parent so that
+      # subclassing a Commander yields a real superset: the subclass
+      # handles everything the parent did, plus whatever it adds. Handler
+      # methods are already inherited (they're +define_method+'d), so only
+      # the type => class table needs copying. Mirrors {Router.inherited}.
+      #
+      # +super+ is required: {Scheduling} prepends a +SubclassHook#inherited+
+      # that sets up the per-subclass +Schedules+ namespace.
+      def inherited(subclass)
+        super
+        subclass.command_registry.merge!(command_registry)
+      end
+
       def command_registry
         @command_registry ||= {}
       end

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -47,6 +47,103 @@ RSpec.describe 'Sidereal::App.commander' do
   end
 end
 
+RSpec.describe 'Sidereal::App.commands' do
+  # Reusable command messages for the additional-commander tests.
+  CommandsCmdA = Sidereal::Message.define('app_commands.cmd_a')
+  CommandsCmdB = Sidereal::Message.define('app_commands.cmd_b')
+  CommandsExtra = Sidereal::Message.define('app_commands.extra')
+
+  # A standalone commander class (defined outside any App), simulating a
+  # custom commander implementation a user would register.
+  class StandaloneCommander < Sidereal::Commander
+    command CommandsCmdA do |cmd|
+    end
+  end
+
+  it 'registers an existing commander class in the global registry' do
+    Class.new(Sidereal::App) { commands StandaloneCommander }
+
+    expect(Sidereal.registry[CommandsCmdA]).to eq(StandaloneCommander)
+  end
+
+  it 'builds and registers an anonymous commander from a block' do
+    app = Class.new(Sidereal::App) do
+      commands do
+        command CommandsCmdB do |cmd|
+        end
+      end
+    end
+
+    commander = Sidereal.registry[CommandsCmdB]
+    expect(commander).not_to be_nil
+    expect(commander).to be < Sidereal::Commander
+    # The default inline commander is untouched by `commands`.
+    expect(commander).not_to eq(app.commander)
+  end
+
+  it 'registers a subclass that extends a passed commander, without mutating it' do
+    Class.new(Sidereal::App) do
+      commands StandaloneCommander do
+        command CommandsExtra do |cmd|
+        end
+      end
+    end
+
+    registered = Sidereal.registry[CommandsExtra]
+    expect(registered).to be < StandaloneCommander
+    # Inherited command still routes to the same subclass.
+    expect(Sidereal.registry[CommandsCmdA]).to eq(registered)
+    # The passed class is never mutated.
+    expect(StandaloneCommander.handled_commands).not_to include(CommandsExtra)
+  end
+
+  it 'leaves the default inline commander as the target of .command' do
+    app = Class.new(Sidereal::App) do
+      commands StandaloneCommander
+      command CommandsCmdB do |cmd|
+      end
+    end
+
+    expect(Sidereal.registry[CommandsCmdB]).to eq(app.commander)
+    expect(Sidereal.registry[CommandsCmdA]).to eq(StandaloneCommander)
+  end
+
+  it 'raises DuplicateHandler when two commanders claim the same command' do
+    expect {
+      Class.new(Sidereal::App) do
+        command CommandsCmdA do |cmd|
+        end
+        commands StandaloneCommander
+      end
+    }.to raise_error(Sidereal::Registry::DuplicateHandler)
+  end
+
+  it 'raises ArgumentError when given neither a class nor a block' do
+    expect {
+      Class.new(Sidereal::App) { commands }
+    }.to raise_error(ArgumentError)
+  end
+end
+
+RSpec.describe 'Sidereal::App.command_helpers' do
+  CommandHelperCmd = Sidereal::Message.define('app_helpers.run')
+
+  it 'adds helper methods to the default inline commander' do
+    captured = []
+    app = Class.new(Sidereal::App) do
+      command CommandHelperCmd do |cmd|
+        captured << greeting
+      end
+      command_helpers do
+        private def greeting = 'hello from helper'
+      end
+    end
+
+    app.commander.handle(CommandHelperCmd.new, pubsub: Sidereal::PubSub::Memory.new)
+    expect(captured).to eq(['hello from helper'])
+  end
+end
+
 RSpec.describe 'Sidereal::App#component' do
   include Rack::Test::Methods
 

--- a/spec/commander_spec.rb
+++ b/spec/commander_spec.rb
@@ -77,6 +77,43 @@ RSpec.describe Sidereal::Commander do
     end
   end
 
+  describe 'subclassing (inherited hook)' do
+    it 'seeds a subclass command registry from its parent' do
+      parent = Class.new(Sidereal::Commander) do
+        command TestAddItem do |cmd|
+        end
+      end
+
+      child = Class.new(parent)
+
+      expect(child.command_registry).to have_key('test.add_item')
+      expect(child.handled_commands).to include(TestAddItem)
+    end
+
+    it 'lets a subclass add commands without mutating its parent' do
+      parent = Class.new(Sidereal::Commander) do
+        command TestAddItem do |cmd|
+        end
+      end
+
+      child = Class.new(parent) do
+        command TestSendEmail do |cmd|
+        end
+      end
+
+      expect(child.handled_commands).to include(TestAddItem, TestSendEmail)
+      expect(parent.handled_commands).to include(TestAddItem)
+      expect(parent.handled_commands).not_to include(TestSendEmail)
+    end
+
+    it 'still sets up the Schedules namespace for the subclass' do
+      parent = Class.new(Sidereal::Commander)
+      child = Class.new(parent)
+
+      expect(child.const_defined?(:Schedules, false)).to be(true)
+    end
+  end
+
   describe '.schedule (Scheduling mixin)' do
     # Heavy DSL coverage lives in spec/scheduling_spec.rb against a
     # minimal stand-in host. These tests only verify the Commander's


### PR DESCRIPTION
## What

Adds support for registering **multiple commanders** per `App`, beyond the single default inline commander.

- `commands SomeCommander` — register an existing commander class.
- `commands SomeCommander do … end` — register a **subclass** of it (the passed class is never mutated; the subclass inherits its command registrations and adds the block's).
- `commands do … end` — build and register a fresh anonymous commander.
- `command_helpers(&block)` now extends the **default** inline commander (previously a bare alias of `commands`).
- `command` / `schedule` / `commander` are unchanged — they still target the default commander.

A new `Commander.inherited` hook copies the parent's `command_registry` into a subclass (mirrors `Router.inherited`), so subclassing yields a real superset.

## Why

First step toward exploring alternative commander implementations (dataflow, behaviour trees, state machines). The runtime was *already* multi-commander capable — the global `Sidereal.registry` maps each command class to its commander and the dispatcher routes via `@registry[msg.class]`. The only missing piece was App-level DSL to register additional commanders, so this is purely a DSL reshape. `Sidereal.register` only requires `#handled_commands`, so custom commanders don't need to subclass `Sidereal::Commander`.

The previous `commands(cmder)` *replaced* the default commander and was unused dead code; its block form is now reassigned to `command_helpers`.

## How

- `lib/sidereal/commander.rb` — add `inherited` hook copying `command_registry` to subclasses; calls `super` so `Scheduling`'s `SubclassHook` (per-subclass `Schedules` namespace) still runs.
- `lib/sidereal/app.rb` — rewrite `commands` to register additional commanders (class / class+block-as-subclass / anonymous block; `ArgumentError` if neither); rewrite `command_helpers` to `class_eval` onto the default commander.
- No changes to `Registry`, `Dispatcher`, or `Sidereal.register`.

### Notes

- `Registry#[]=` still raises `DuplicateHandler` if two commanders claim the same command class — the desired guard.
- Block-form commanders are anonymous (no naming constants); a name would only matter for `Scheduling#__type_namespace`, so schedule-bearing extra commanders should be registered as named classes.
