### PR TITLE
Sourced integration + pluggable backend integrations (Config#use)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,4 +15,5 @@ gem 'debug'
 
 group :development do
   gem 'docco', github: 'ismasan/docco'
+  gem 'sourced', path: '../sourced'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,16 @@ GIT
       kramdown-parser-gfm
 
 PATH
+  remote: ../sourced
+  specs:
+    sourced (0.0.1)
+      async
+      plumb (>= 0.0.17)
+      sequel
+      sourced-message
+      sqlite3
+
+PATH
   remote: .
   specs:
     sidereal (0.1.0)
@@ -113,9 +123,12 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.7)
+    sequel (5.106.0)
+      bigdecimal
     sourced-message (0.1.0)
       fugit
       plumb (>= 0.0.17)
+    sqlite3 (2.9.5-arm64-darwin)
     stringio (3.2.0)
     traces (0.18.2)
     tsort (0.2.0)
@@ -125,7 +138,6 @@ GEM
 
 PLATFORMS
   arm64-darwin-24
-  ruby
 
 DEPENDENCIES
   debug
@@ -135,6 +147,7 @@ DEPENDENCIES
   rake (~> 13.0)
   rspec (~> 3.0)
   sidereal!
+  sourced!
 
 CHECKSUMS
   async (2.38.1) sha256=72ba6b7de04d852355458bfe891221226bb7d29f055f5cb043ae3345497f8cec
@@ -182,8 +195,11 @@ CHECKSUMS
   rspec-expectations (3.13.5) sha256=33a4d3a1d95060aea4c94e9f237030a8f9eae5615e9bd85718fe3a09e4b58836
   rspec-mocks (3.13.8) sha256=086ad3d3d17533f4237643de0b5c42f04b66348c28bf6b9c2d3f4a3b01af1d47
   rspec-support (3.13.7) sha256=0640e5570872aafefd79867901deeeeb40b0c9875a36b983d85f54fb7381c47c
+  sequel (5.106.0) sha256=0e6677f230e724ecbc9b4d5fc95ef9a69997cfb24c60fff84268185e0bb254cd
   sidereal (0.1.0)
+  sourced (0.0.1)
   sourced-message (0.1.0) sha256=e86f0e7c0e387d02c5811d2968dc48cb1e934c9244268974f78dc90714fab60d
+  sqlite3 (2.9.5-arm64-darwin) sha256=d0cf444a70fc9395d513cfbcc1e6719e224aa645314e3824cb0474c721425aa2
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
   traces (0.18.2) sha256=80f1649cb4daace1d7174b81f3b3b7427af0b93047759ba349960cb8f315e214
   tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f

--- a/README.md
+++ b/README.md
@@ -936,6 +936,8 @@ Sidereal.configure do |c|
 end
 ```
 
+**Integrations.** Backends that provide several collaborators at once (e.g. a store + dispatcher pair, plus bridging) ship as *integrations*, applied with `c.use(SomeIntegration, **opts)` — `use_file_system!` is itself one. See [Using Sourced as a backend](#using-sourced-as-a-backend) for the canonical example.
+
 ### Filesystem store
 
 `Sidereal::Store::FileSystem` is a built-in durable store that survives process restarts and lets multiple worker processes on the same host share a queue. It also honors [scheduled commands](#scheduled-commands), unlike the default in-memory store.
@@ -1167,29 +1169,43 @@ end
 
 # Point Sidereal at Sourced's store and dispatcher
 Sidereal.configure do |c|
-  c.store      = Sourced.config.store
-  c.dispatcher = Sourced::Dispatcher
+  # Use file-system version of pubsub, elector
+  c.use_file_system!
+  # Use Sourced as message store and dispatcher
+  c.use Sidereal::Integrations::Sourced
 end
 ```
 
-`require 'sidereal/integrations/sourced'` wires two things for you:
+`c.use Sidereal::Integrations::Sourced` wires several things for you:
 
+- **Store + dispatcher** — Sourced becomes Sidereal's message store and dispatcher. Sidereal Commanders (`command` / `handle`) also register as Sourced reactors, so they run on the same runtime alongside your Deciders and Projectors. Instead of configuring `Sourced.configure { ... }` yourself, you can let the integration do it — pass a **callable** store so each forked worker opens its own connection:
+
+  ```ruby
+  c.use Sidereal::Integrations::Sourced, store: -> { Sequel.sqlite('db/app.db') }
+  ```
+
+- **Auto-publish to PubSub** — Deciders' emitted events and Projectors' updates are published to Sidereal's PubSub automatically (see [Auto-publish](#auto-publish) below), so Pages re-render over SSE with no hand-written bridge code in your reactors.
 - **Error toasts / reporting** — Sourced's retry and terminal-failure events are reported to `Sidereal.exceptions`, so the [default error toasts](#default-dev-ui-error-toasts) appear and any `on_retry` / `on_failure` / `on_fatal` subscribers (e.g. an APM hook) fire. When Sourced is the dispatcher it owns retry/fail orchestration, so Sidereal's *automatic* exception reporting doesn't run — this bridge is what surfaces failures in the UI.
-- **Fork safety** — under the default Falcon setup each worker loads `boot.rb` in its own process, so `Sourced.configure { c.store = Sequel.sqlite(...) }` opens a fresh SQLite connection per worker. Nothing is inherited across the fork, so there is no stale-connection problem and no post-fork reconnection step to wire up.
+- **Fork safety** — under the default Falcon setup each worker loads `boot.rb` in its own process, and the dispatcher calls `Sourced.setup!` on start, so a callable store (or a per-worker `Sourced.configure`) opens a fresh SQLite connection per worker. Nothing is inherited across the fork, so there is no stale-connection problem and no post-fork reconnection step to wire up.
+
+> **Multi-process:** `use_file_system!` (cross-process pubsub + file-lock election) is required whenever you run more than one worker — otherwise the in-process pubsub/elector can't fan SSE updates across processes. If you start multiple workers with the default in-process subsystems, Sidereal **refuses to boot** with a loud error telling you to add it (see [Running with Falcon](#running-with-falcon)).
 
 ### Defining messages and Deciders
 
 With Sourced as the backend, use Sourced messages and Deciders instead of `App.command`:
 
 ```ruby
-# Define messages using Sourced's message class
+# Define messages using Sourced's message class. AddTodo carries todo_id
+# because the Decider partitions by it (generate it client-side, or stamp it
+# in a `before_command` hook).
 AddTodo = Sourced::Message.define('todos.add') do
+  attribute :todo_id, String
   attribute :title, String
 end
 
 TodoAdded = Sourced::Message.define('todos.added') do
-  attribute :title, String
   attribute :todo_id, String
+  attribute :title, String
 end
 
 # Define a Decider (replaces App.command for async processing)
@@ -1197,25 +1213,55 @@ class TodoDecider < Sourced::Decider
   partition_by :todo_id
 
   command AddTodo do |state, cmd|
-    event TodoAdded, title: cmd.payload.title, todo_id: SecureRandom.uuid
-  end
-
-  # Publish events to Sidereal's PubSub for SSE streaming
-  after_sync do |state:, events:|
-    events.each do |evt|
-      Sidereal.pubsub.publish(Sidereal.channels.for(evt), evt)
-    end
+    event TodoAdded, todo_id: cmd.payload.todo_id, title: cmd.payload.title
   end
 end
 
 Sourced.register(TodoDecider)
 ```
 
-The `after_sync` block runs after the store transaction commits and pushes events into Sidereal's PubSub, where Page reactions pick them up and stream DOM updates via SSE. Sourced's dispatcher doesn't auto-publish to PubSub the way Sidereal's does, so the channel is resolved by looking up `Sidereal.channels.for(evt)` against whatever the App registered with the `channel_name` macro.
+You don't write any publishing code — that's the auto-publish below.
+
+### Auto-publish
+
+The integration publishes reactor output to Sidereal's PubSub for you, so Page reactions pick it up and stream DOM updates via SSE. Every path resolves its channel through your App's `channel_name` resolver (`Sidereal.channels.for(evt)`), and a publish/resolver failure is reported to `Sidereal.exceptions` (it's terminal — the store already committed).
+
+- **Deciders** publish the **events they emitted**. The integration injects one generic `after_sync` into every `Sourced::Decider` subclass, so no per-reactor wiring is needed.
+- **Projectors** publish a synthetic **"projected" signal** so Pages know to re-fetch their read model. You don't define or publish it: the integration wraps the `partition_by` macro to auto-define a `Projected` event class (one attribute per partition key) and register an `after_sync` that publishes it after each committed batch:
+
+  ```ruby
+  class TodosProjector < Sourced::Projector::StateStored
+    partition_by :todo_id
+
+    evolve TodoDecider::TodoAdded do |state, evt|
+      # update the read model...
+    end
+
+    sync do |state:, **|
+      # persist the read model...
+    end
+  end
+  # => auto-defines TodosProjector::Projected (with a `todo_id` attribute),
+  #    published after every batch via Sidereal.channels.for.
+
+  Sourced.register(TodosProjector)
+  ```
+
+  Pages react on the generated signal:
+
+  ```ruby
+  on TodosProjector::Projected do |_evt|
+    browser.patch_elements load(params)
+  end
+  ```
+
+  The signal's payload is the projector's full partition tuple, so multi-key partitions work too — `partition_by(:student_id, :course_id)` yields a two-attribute `Projected`, and your `channel_name` resolver routes it just like your domain events.
+
+Sidereal Commanders are unaffected — they're not `Decider`/`Projector` subclasses and keep publishing via their own path, so there's no double-publish.
 
 ### Pages and App
 
-Pages and the App work the same way. `handle` exposes commands to the browser, and Page `on` reactions respond to events from the Decider's `after_sync`:
+Pages and the App work the same way. `handle` exposes commands to the browser, and Page `on` reactions respond to the auto-published events:
 
 ```ruby
 class TodoPage < Sidereal::Page
@@ -1247,7 +1293,7 @@ end
 
 ### Synchronous Sourced handling
 
-You can also process a command synchronously during the HTTP request using `Sourced.handle!`, which loads history, runs the Decider, appends events, and returns immediately:
+You can also process a command synchronously during the HTTP request using `Sourced.handle!`, which loads history, runs the Decider, appends events, and returns immediately. Unlike the async dispatcher path, `handle!` does **not** run the reactor's `after_sync`, so the [auto-publish](#auto-publish) doesn't fire here — publish the returned events yourself if other connected browsers need them:
 
 ```ruby
 handle AddTodo do |cmd|

--- a/examples/chat/Gemfile
+++ b/examples/chat/Gemfile
@@ -5,6 +5,9 @@ source "https://rubygems.org"
 gem "sidereal", path: "../.."
 gem "falcon"
 
+# Sourced backend for the Sidereal integration (store + dispatcher).
+gem 'sourced', github: 'ismasan/sourced', branch: 'ccc'
+
 gem "ruby_llm", "~> 1.14"
 gem 'irb'
 

--- a/examples/chat/Gemfile.lock
+++ b/examples/chat/Gemfile.lock
@@ -1,3 +1,15 @@
+GIT
+  remote: https://github.com/ismasan/sourced.git
+  revision: 4075bf0d5e12f956fd141df294ca53c39a7d7c68
+  branch: ccc
+  specs:
+    sourced (0.0.1)
+      async
+      plumb (>= 0.0.17)
+      sequel
+      sourced-message
+      sqlite3
+
 PATH
   remote: ../..
   specs:
@@ -7,7 +19,6 @@ PATH
       datastar (~> 1.0.4)
       fugit
       phlex
-      plumb (~> 0.0.17)
       rack (~> 3)
       rack-session
       sourced-message
@@ -167,9 +178,12 @@ GEM
     samovar (2.4.1)
       console (~> 1.0)
       mapping (~> 1.0)
+    sequel (5.106.0)
+      bigdecimal
     sourced-message (0.1.0)
       fugit
       plumb (>= 0.0.17)
+    sqlite3 (2.9.5-arm64-darwin)
     string-format (0.2.0)
     stringio (3.2.0)
     traces (0.18.2)
@@ -181,7 +195,6 @@ GEM
 
 PLATFORMS
   arm64-darwin-24
-  ruby
 
 DEPENDENCIES
   dotenv (~> 3.2)
@@ -190,6 +203,7 @@ DEPENDENCIES
   kramdown
   ruby_llm (~> 1.14)
   sidereal!
+  sourced!
 
 CHECKSUMS
   async (2.38.1) sha256=72ba6b7de04d852355458bfe891221226bb7d29f055f5cb043ae3345497f8cec
@@ -256,8 +270,11 @@ CHECKSUMS
   ruby_llm (1.14.0) sha256=57c6f7034fc4a44504ea137d70f853b07824f1c1cdbe774ab3ab3522e7098deb
   ruby_llm-schema (0.3.0) sha256=a591edc5ca1b7f0304f0e2261de61ba4b3bea17be09f5cf7558153adfda3dec6
   samovar (2.4.1) sha256=c3b91dd0580771e3bc600621c1111f29542529dcffafaac3b6bf068b3f309e80
+  sequel (5.106.0) sha256=0e6677f230e724ecbc9b4d5fc95ef9a69997cfb24c60fff84268185e0bb254cd
   sidereal (0.1.0)
+  sourced (0.0.1)
   sourced-message (0.1.0) sha256=e86f0e7c0e387d02c5811d2968dc48cb1e934c9244268974f78dc90714fab60d
+  sqlite3 (2.9.5-arm64-darwin) sha256=d0cf444a70fc9395d513cfbcc1e6719e224aa645314e3824cb0474c721425aa2
   string-format (0.2.0) sha256=bc981c14116b061f12134549f32fa2d61a17b5a35dd6fd36596c21722a789af6
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
   traces (0.18.2) sha256=80f1649cb4daace1d7174b81f3b3b7427af0b93047759ba349960cb8f315e214

--- a/examples/chat/app.rb
+++ b/examples/chat/app.rb
@@ -3,16 +3,9 @@
 require 'dotenv'
 Dotenv.load '.env'
 
-require 'sidereal'
+# Sidereal is required and configured (Sourced store + dispatcher, filesystem
+# pubsub/elector) in boot.rb, which config.ru loads before this file.
 require 'ruby_llm'
-
-Sidereal.configure do |c|
-  c.workers = 3
-  # Filesystem store + unix-socket pubsub + file-lock elector under tmp/, so
-  # multiple worker processes share one store and one pubsub broker (only the
-  # elected leader runs scheduled blocks). Override any one with c.store= etc.
-  c.use_file_system!(dir: 'tmp')
-end
 
 RubyLLM.configure do |config|
   # Add keys ONLY for the providers you intend to use.

--- a/examples/chat/boot.rb
+++ b/examples/chat/boot.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'sequel'
+require 'sqlite3'
+require 'sidereal'
+require 'sidereal/integrations/sourced'
+
+DB_PATH = File.expand_path('tmp/chat.db', __dir__)
+FileUtils.mkdir_p(File.dirname(DB_PATH))
+
+# Each forked Falcon worker loads this file in its own process, so the Sourced
+# SQLite store below is established fresh per worker (SQLite connections aren't
+# fork-safe, but nothing is inherited across the fork).
+Sourced.configure do |config|
+  config.store = Sequel.sqlite(DB_PATH) unless ENV['TEST']
+  # Poll every 0.5s so cross-process dispatches (e.g. `Sidereal.dispatch!` from a
+  # console) are picked up quickly. SQLite has no LISTEN/NOTIFY, so out-of-process
+  # appends rely on this catch-up poll rather than the in-process notifier.
+  config.catchup_interval = 0.5
+end
+
+# This demo has no Sourced deciders/projectors — only Sidereal Commanders
+# (defined in app.rb). The Sourced integration's dispatcher auto-registers
+# those Commanders with Sourced before starting the runtime, so there's
+# nothing to Sourced.register here.
+
+Sidereal.configure do |c|
+  c.workers = 3
+  # Cross-process pubsub + leader election (unix socket + file lock under
+  # tmp/), so SSE updates fan out to subscribers on every worker via one
+  # elected broker — required for count > 1.
+  c.use_file_system!(dir: 'tmp')
+  # ...but keep Sourced's SQLite store + dispatcher, not the FS store. One call
+  # wires both (+ the error bridge). Sourced is already configured above, so no
+  # `store:` arg.
+  c.use Sidereal::Integrations::Sourced
+end

--- a/examples/chat/config.ru
+++ b/examples/chat/config.ru
@@ -1,3 +1,4 @@
+require_relative "boot"
 require_relative "app"
 
 use Rack::Static, urls: ['/css', '/js'], root: "public"

--- a/examples/chat/falcon.rb
+++ b/examples/chat/falcon.rb
@@ -1,13 +1,17 @@
 #!/usr/bin/env falcon-host
 # frozen_string_literal: true
 
-require_relative 'app'
+require 'sidereal'
 require 'sidereal/falcon/environment'
 
-# Set PORT in the environment to launch on a different port. This lets you
-# run multiple master processes in separate terminals all backed by the same
-# tmp/pubsub.sock and tmp/store/ — exercising the cross-process FileSystem
-# store + Unix pubsub (configured via c.use_file_system!(dir: 'tmp') in app.rb):
+# Lazy-load: the controller doesn't require the app — each forked worker loads
+# config.ru (→ boot.rb → app.rb) in its own process, so the Sourced SQLite
+# connection is established fresh per worker (see boot.rb).
+#
+# Set PORT in the environment to launch on a different port. This lets you run
+# multiple master processes in separate terminals all backed by the same
+# tmp/chat.db (Sourced store) and tmp/pubsub.sock (Unix pubsub) — configured in
+# boot.rb via the Sourced integration + c.use_file_system!(dir: 'tmp'):
 #
 #   bundle exec falcon-host falcon.rb              # → http://localhost:9293
 #   PORT=9294 bundle exec falcon-host falcon.rb    # → http://localhost:9294

--- a/examples/chess/boot.rb
+++ b/examples/chess/boot.rb
@@ -34,8 +34,8 @@ Sourced.register(GamesProjector)
 # no real store and the unit specs drive the decider directly.
 unless ENV['TEST']
   Sidereal.configure do |c|
-    c.store      = Sourced.config.store
-    c.dispatcher = Sourced::Dispatcher
+    c.use_file_system!
+    c.use Sidereal::Integrations::Sourced
   end
 end
 

--- a/examples/chess/domain/game.rb
+++ b/examples/chess/domain/game.rb
@@ -209,14 +209,4 @@ class Game < Sourced::Decider
     return 'black' if username == state.black_username
     nil
   end
-
-  # ---- Bridge to Sidereal SSE ----
-
-  after_sync do |state:, events:, **|
-    events.each do |evt|
-      ch = Sidereal.channels.for(evt)
-      Console.info("[chess] publishing #{evt.type} → #{ch}")
-      Sidereal.pubsub.publish(ch, evt)
-    end
-  end
 end

--- a/examples/chess/domain/games_projector.rb
+++ b/examples/chess/domain/games_projector.rb
@@ -52,18 +52,9 @@ class GamesProjector < Sourced::Projector::StateStored
     Sourced.store.db[:games].insert_conflict(:replace).insert(state)
   end
 
-  # Synthetic event published after each upsert so HomePage subscribers
-  # never read stale rows from the lobby table.
-  GameProjected = Sourced::Event.define('chess.games.projected') do
-    attribute :game_id, Sourced::Types::UUID::V4
-  end
-
-  after_sync do |state:, **|
-    next unless state[:game_id]
-
-    evt = GameProjected.new(payload: { game_id: state[:game_id] })
-    Sidereal.pubsub.publish("games.#{state[:game_id]}", evt)
-  end
+  # A `Projected` signal (attribute: game_id) is auto-generated from
+  # `partition_by` and published after each committed batch by
+  # Sidereal::Integrations::Sourced — routed via Sidereal.channels.for.
 
   def self.on_reset
     Sourced.store.db[:games].delete

--- a/examples/chess/spec/domain/games_projector_spec.rb
+++ b/examples/chess/spec/domain/games_projector_spec.rb
@@ -143,17 +143,26 @@ RSpec.describe GamesProjector do
     end
   end
 
-  describe 'after_sync — pubsub' do
-    it 'publishes a GameProjected event on the per-game channel' do
+  describe 'auto-published Projected signal' do
+    # boot.rb doesn't load app.rb (where the resolver lives), so register the
+    # per-game channel here to assert the auto-injected after_sync routes
+    # through Sidereal.channels.for.
+    before do
+      Sidereal.channels.channel_name(GamesProjector::Projected) { |m| "games.#{m.payload.game_id}" }
+    end
+
+    it 'publishes a Projected signal on the per-game channel after each batch' do
       expect(Sidereal.pubsub).to receive(:publish) do |channel, evt|
         expect(channel).to eq("games.#{game_id}")
-        expect(evt).to be_a(GamesProjector::GameProjected)
+        expect(evt).to be_a(GamesProjector::Projected)
         expect(evt.payload.game_id).to eq(game_id)
       end
 
+      # No-block form runs Sync/AfterSync exactly once (the block form of
+      # `.then!` re-runs them via compute_state, double-firing the publish).
       with_reactor(GamesProjector, game_id:)
         .given(Game::GameCreated, game_id:, white_username: white, initial_fen: ChessEngine::INITIAL_FEN)
-        .then! { |_| }
+        .then!([])
     end
   end
 

--- a/examples/chess/ui/home_page.rb
+++ b/examples/chess/ui/home_page.rb
@@ -7,8 +7,8 @@ class HomePage < Sidereal::Page
   path '/'
 
   # Re-render the lobby whenever any game projector commits — that's the
-  # synthetic event the GamesProjector publishes after each upsert.
-  on GamesProjector::GameProjected do |_evt|
+  # synthetic Projected signal the GamesProjector auto-publishes after each upsert.
+  on GamesProjector::Projected do |_evt|
     browser.patch_elements load(params)
   end
 
@@ -28,7 +28,7 @@ class HomePage < Sidereal::Page
   end
 
   # Glob subscription: catches every game's events (per-game channels are
-  # named `games.<id>`) plus the synthetic GameProjected. Sidereal page
+  # named `games.<id>`) plus the synthetic Projected signal. Sidereal page
   # reactions only fire on declared `on` events, so the glob is safe.
   def channel_name = 'games.>'
 

--- a/examples/sourced_donations/Gemfile.lock
+++ b/examples/sourced_donations/Gemfile.lock
@@ -11,13 +11,15 @@ GIT
 
 GIT
   remote: https://github.com/ismasan/sourced.git
-  revision: bd065f199b25605202364e05edfe7cd73b58b896
+  revision: 4075bf0d5e12f956fd141df294ca53c39a7d7c68
   branch: ccc
   specs:
     sourced (0.0.1)
       async
       plumb (>= 0.0.17)
+      sequel
       sourced-message
+      sqlite3
 
 PATH
   remote: ../..

--- a/examples/sourced_donations/boot.rb
+++ b/examples/sourced_donations/boot.rb
@@ -32,9 +32,11 @@ unless ENV['TEST']
     # ./storage), so SSE updates fan out to subscribers on every worker via
     # one elected broker — required for count > 1.
     c.use_file_system!
-    # ...but keep Sourced's SQLite store + dispatcher, not the FS store.
-    c.store      = Sourced.config.store
-    c.dispatcher = Sourced::Dispatcher
+    # ...but keep Sourced's SQLite store + dispatcher, not the FS store. One call
+    # wires both (+ the error bridge). Sourced is already configured above, so no
+    # `store:` arg. The dispatcher also auto-registers any Sidereal Commanders
+    # with Sourced before starting the runtime (none in this demo yet).
+    c.use Sidereal::Integrations::Sourced
   end
 end
 

--- a/examples/sourced_donations/domain/campaign.rb
+++ b/examples/sourced_donations/domain/campaign.rb
@@ -72,12 +72,4 @@ class Campaign < Sourced::Decider
 
     event CampaignClosed, campaign_id: cmd.payload.campaign_id
   end
-
-  # ---- Bridge to Sidereal SSE ----
-
-  after_sync do |state:, events:, **|
-    events.each do |evt|
-      Sidereal.pubsub.publish(Sidereal.channels.for(evt), evt)
-    end
-  end
 end

--- a/examples/sourced_donations/domain/campaigns_projector.rb
+++ b/examples/sourced_donations/domain/campaigns_projector.rb
@@ -34,18 +34,9 @@ class CampaignsProjector < Sourced::Projector::StateStored
     Sourced.store.db[:campaigns].insert_conflict(:replace).insert(state)
   end
 
-  # Published after the projector commits, so SSE subscribers reading from
-  # the read model never see stale data.
-  CampaignProjected = Sourced::Event.define('campaigns.projected') do
-    attribute :campaign_id, Sourced::Types::UUID::V4
-  end
-
-  after_sync do |state:, **|
-    next unless state[:campaign_id]
-
-    evt = CampaignProjected.new(payload: { campaign_id: state[:campaign_id] })
-    Sidereal.pubsub.publish("campaigns.#{state[:campaign_id]}", evt)
-  end
+  # A `Projected` signal (attribute: campaign_id) is auto-generated from
+  # `partition_by` and published after each committed batch by
+  # Sidereal::Integrations::Sourced — routed via Sidereal.channels.for.
 
   def self.on_reset
     Sourced.store.db[:campaigns].delete

--- a/examples/sourced_donations/domain/donation.rb
+++ b/examples/sourced_donations/domain/donation.rb
@@ -331,12 +331,4 @@ class Donation < Sourced::Decider
       campaign_id: evt.payload.campaign_id,
       payment_reference:
   end
-
-  # ---- Bridge to Sidereal SSE ----
-
-  after_sync do |state:, events:, **|
-    events.each do |evt|
-      Sidereal.pubsub.publish(Sidereal.channels.for(evt), evt)
-    end
-  end
 end

--- a/examples/sourced_donations/ui/campaigns_list_page.rb
+++ b/examples/sourced_donations/ui/campaigns_list_page.rb
@@ -3,7 +3,7 @@
 class CampaignsListPage < Sidereal::Page
   path '/'
 
-  on CampaignsProjector::CampaignProjected do |_evt|
+  on CampaignsProjector::Projected do |_evt|
     browser.patch_elements load(params)
   end
 

--- a/lib/sidereal.rb
+++ b/lib/sidereal.rb
@@ -67,14 +67,8 @@ module Sidereal
     # @param dir [String] base directory for store files, socket, and lock
     # @return [self]
     def use_file_system!(dir: 'storage')
-      require 'sidereal/store/file_system'
-      require 'sidereal/pubsub/unix'
-      require 'sidereal/elector/file_system'
-
-      self.store   = Store::FileSystem.new(root: File.join(dir, 'store'))
-      self.pubsub  = PubSub::Unix.new(socket_path: File.join(dir, 'pubsub.sock'))
-      self.elector = Elector::FileSystem.new(lock_path: File.join(dir, 'leader.lock'))
-      self
+      require 'sidereal/integrations/file_system'
+      use(Integrations::FileSystem, dir:)
     end
 
     # Apply a backend integration in one call. The integration's +#setup+ wires

--- a/lib/sidereal.rb
+++ b/lib/sidereal.rb
@@ -16,6 +16,9 @@ module Sidereal
   # It's up to dispatcher implementations how to use the store to claim commands
   # Ex. Sourced's store has a more sophisticated claim mechanism than Sidereal::Store
   StoreWriterInterface = Types::Interface[:append]
+  # A backend integration self-applies to a Configuration via #setup(config, **opts).
+  # See Configuration#use.
+  IntegrationInterface = Types::Interface[:setup]
 
   def self.message_method_name(prefix, name)
     "__handle_#{prefix}_#{name.split('::').map(&:downcase).join('_')}"
@@ -71,6 +74,21 @@ module Sidereal
       self.store   = Store::FileSystem.new(root: File.join(dir, 'store'))
       self.pubsub  = PubSub::Unix.new(socket_path: File.join(dir, 'pubsub.sock'))
       self.elector = Elector::FileSystem.new(lock_path: File.join(dir, 'leader.lock'))
+      self
+    end
+
+    # Apply a backend integration in one call. The integration's +#setup+ wires
+    # whatever collaborators it provides (e.g. a store + dispatcher pair, plus any
+    # bridging). Like {#use_file_system!} it returns +self+ and can be called in or
+    # out of a {Sidereal.configure} block.
+    #
+    #   c.use Sidereal::Integrations::Sourced                  # reads Sourced.config.store
+    #   c.use Sidereal::Integrations::Sourced, store: sequel_db # configures Sourced too
+    #
+    # @param integration [#setup] responds to +setup(config, **opts)+
+    # @return [self]
+    def use(integration, **opts)
+      IntegrationInterface.parse(integration).setup(self, **opts)
       self
     end
   end

--- a/lib/sidereal.rb
+++ b/lib/sidereal.rb
@@ -2,6 +2,7 @@
 
 require 'async'
 require 'console'
+require_relative 'sidereal/logging' # quiets benign SSE-disconnect task warnings
 require_relative 'sidereal/version'
 require_relative 'sidereal/types'
 require_relative 'sidereal/utils'

--- a/lib/sidereal.rb
+++ b/lib/sidereal.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 require 'async'
+require 'console'
 require_relative 'sidereal/version'
 require_relative 'sidereal/types'
 require_relative 'sidereal/utils'
+require 'sidereal/single_process'
 
 module Sidereal
   class Error < StandardError; end
@@ -85,6 +87,19 @@ module Sidereal
       IntegrationInterface.parse(integration).setup(self, **opts)
       self
     end
+
+    # Labels of the configured subsystems whose state lives entirely within one
+    # process (they carry the {SingleProcess} marker). These break cross-process
+    # fan-out under a forking host, so the list drives the multi-process startup
+    # warning ({Sidereal.warn_unsafe_topology}). Empty once every subsystem is
+    # cross-process safe — e.g. after {#use_file_system!}.
+    #
+    # @return [Array<String>] e.g. +["pubsub", "elector"]+
+    def single_process_subsystems
+      { 'store' => @store, 'pubsub' => @pubsub, 'elector' => @elector }
+        .select { |_, impl| impl.is_a?(SingleProcess) }
+        .keys
+    end
   end
 
   def self.config
@@ -154,6 +169,50 @@ module Sidereal
   def self.store = config.store
   def self.dispatcher = config.dispatcher
   def self.elector = config.elector
+
+  # Fail fast at startup when in-process-only subsystems are configured in a
+  # multi-process (forked-worker) deployment, where their in-memory state isn't
+  # shared and cross-process SSE fan-out silently breaks. Logs a loud,
+  # multi-line error and terminates the process — refusing to boot into a
+  # broken topology is safer than serving requests that appear to work but
+  # never propagate updates across workers.
+  #
+  # A no-op for a single worker or once every subsystem is cross-process safe
+  # (e.g. after {Configuration#use_file_system!}). Hosts that fork (the Falcon
+  # environment) call this with their worker-process count; single-process
+  # hosts needn't.
+  #
+  # @param process_count [Integer] number of forked worker processes
+  # @param config [Configuration] the configuration to inspect (defaults to the
+  #   process-global {.config}; injected in tests)
+  # @return [void] returns only when the topology is safe; otherwise exits
+  def self.check_topology!(process_count, config: self.config)
+    return if process_count.to_i <= 1
+
+    subsystems = config.single_process_subsystems
+    return if subsystems.empty?
+
+    verb = subsystems.one? ? 'is' : 'are'
+    Console.error(self, <<~MSG.chomp, subsystems: subsystems, process_count: process_count)
+      Refusing to boot: in-process-only subsystem(s) in a multi-process deployment.
+
+      This host is starting #{process_count} worker processes, but these subsystems
+      keep their state in memory within a single process:
+
+          #{subsystems.join(', ')} #{verb} in-process-only
+
+      Across forked workers this silently breaks the app:
+        - SSE updates published in one worker never reach browsers on another worker.
+        - Every worker believes it is the leader, so background/scheduled work double-runs.
+
+      Fix (pick one):
+        - For single-node, multi-process: call `config.use_file_system!` in your `Sidereal.configure` block, BEFORE any
+          `use <backend>` — switches to the unix-socket pubsub + file-lock elector.
+        - Or run a single worker process (e.g. `count 1` in falcon.rb).
+    MSG
+
+    exit(1)
+  end
 
   # Build a {Host} wired to the process-global collaborators from
   # {.config} (plus the {.channels} / {.exceptions} registries). Call

--- a/lib/sidereal/elector.rb
+++ b/lib/sidereal/elector.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'sidereal/single_process'
+
 module Sidereal
   # Leader election. Modules that should run only on a single elected
   # process per host (or cluster, eventually) inject an Elector and react
@@ -74,6 +76,7 @@ module Sidereal
     # Memory pubsub default).
     class AlwaysLeader
       include Callbacks
+      include SingleProcess
 
       def initialize
         @leader = true

--- a/lib/sidereal/falcon/environment.rb
+++ b/lib/sidereal/falcon/environment.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'etc'
 require 'falcon/environment/server'
 require 'falcon/environment/rackup'
 require 'falcon/service/server'
@@ -35,7 +36,14 @@ module Sidereal
       #
       class Service < ::Falcon::Service::Server
         def run(instance, evaluator)
+          # make_server loads the rackup app (config.ru → boot.rb), which runs
+          # Sidereal.configure — so the config is populated by the time we check.
           server = evaluator.make_server(@bound_endpoint)
+
+          # Fail fast: refuse to boot in-process-only subsystems across forked
+          # workers (their in-memory state isn't shared, so SSE fan-out would
+          # silently fail). Logs a loud error and exits before serving anything.
+          Sidereal.check_topology!(worker_count(evaluator))
 
           @sidereal_host = Sidereal.new_host
 
@@ -47,6 +55,20 @@ module Sidereal
           end
 
           server
+        end
+
+        # Number of forked worker processes Falcon runs for this service.
+        # Falcon's managed environment returns +nil+ from +count+ to mean "one
+        # per processor" (+Etc.nprocessors+); resolve that so the topology check
+        # sees the real fork count. Defensive: any failure falls back to 1.
+        #
+        # @param evaluator [Object] the Falcon environment evaluator
+        # @return [Integer]
+        private def worker_count(evaluator)
+          count = evaluator.respond_to?(:count) ? evaluator.count : 1
+          (count || Etc.nprocessors).to_i
+        rescue StandardError
+          1
         end
 
         def stop(...)

--- a/lib/sidereal/integrations/file_system.rb
+++ b/lib/sidereal/integrations/file_system.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Filesystem / unix-socket integration.
+#
+# Switches the store, pubsub, and elector to the single-machine, multi-process
+# implementations in one call — the set needed to run across multiple worker
+# processes on a single machine. Files and the pubsub socket live under +dir+
+# (default ./storage, relative to the working directory — i.e. the app root when
+# launched with `falcon host` from there).
+#
+# Applied via Sidereal's integration hook (or the {Sidereal::Configuration#use_file_system!}
+# shorthand, which requires this file and delegates here):
+#
+#   Sidereal.configure do |c|
+#     c.use Sidereal::Integrations::FileSystem            # dir: 'storage'
+#     c.use Sidereal::Integrations::FileSystem, dir: 'tmp'
+#   end
+#
+# Override any individual collaborator afterward:
+#
+#   c.use_file_system!
+#   c.store = Sourced.config.store   # keep the filesystem pubsub + elector
+
+require 'sidereal/store/file_system'
+require 'sidereal/pubsub/unix'
+require 'sidereal/elector/file_system'
+
+module Sidereal
+  module Integrations
+    # Backend integration wiring Sidereal's store + pubsub + elector to the
+    # filesystem / unix-socket implementations. Called by
+    # {Sidereal::Configuration#use}.
+    module FileSystem
+      # @param config [Sidereal::Configuration]
+      # @param dir [String] base directory for store files, socket, and lock
+      # @return [Sidereal::Configuration]
+      def self.setup(config, dir: 'storage')
+        config.store   = Store::FileSystem.new(root: File.join(dir, 'store'))
+        config.pubsub  = PubSub::Unix.new(socket_path: File.join(dir, 'pubsub.sock'))
+        config.elector = Elector::FileSystem.new(lock_path: File.join(dir, 'leader.lock'))
+        config
+      end
+    end
+  end
+end

--- a/lib/sidereal/integrations/sourced.rb
+++ b/lib/sidereal/integrations/sourced.rb
@@ -166,6 +166,63 @@ module Sidereal
           ::Sourced::Dispatcher.start(task)
         end
       end
+
+      # Auto-generate a "projected" signal event for every Sourced Projector and
+      # publish it after each committed batch — so Pages re-fetch the read model
+      # without the projector hand-writing an event class, an +after_sync+ block,
+      # or a channel string.
+      #
+      # Prepended onto +Sourced::Projector.singleton_class+, so it wraps the
+      # +partition_by+ macro for the base +StateStored+/+EventSourced+ classes and
+      # every subclass (singleton-class inheritance resolves the prepend live, even
+      # though those subclasses were defined before this integration loaded).
+      #
+      # The signal carries one attribute per partition key (any arity — e.g.
+      # +partition_by(:student_id, :course_id)+ yields a two-attribute signal), and
+      # its payload comes from the projector instance's +partition_values+ (the full
+      # claimed tuple), so the app's +channel_name+ resolver routes it exactly like
+      # the domain events it partitions by.
+      module ProjectorSignals
+        def partition_by(*keys)
+          super
+          __define_projection_signal(partition_keys)
+        end
+
+        # @param keys [Array<Symbol>] resolved partition keys (set by +super+)
+        def __define_projection_signal(keys)
+          return if keys.empty? || const_defined?(:Projected, false)
+
+          type = "#{Sidereal::Utils.snake_case(name)}.projected" # e.g. "campaigns_projector.projected"
+          signal = ::Sourced::Event.define(type) do
+            keys.each { |k| attribute k, ::Sourced::Types::Any }
+          end
+          const_set(:Projected, signal) # Pages reference MyProjector::Projected
+
+          after_sync do |**|
+            vals = partition_values # instance accessor: the full claimed tuple
+            next if vals.empty? || vals.values.any?(&:nil?)
+
+            evt = signal.new(payload: vals)
+            Sidereal.pubsub.publish(Sidereal.channels.for(evt), evt)
+          rescue StandardError => ex
+            Sidereal.exceptions.report_fatal(exception: ex)
+          end
+        end
+      end
     end
   end
 end
+
+# --- Auto-publish wiring (runs at require time, before domain reactors load) ---
+
+# Deciders: publish the domain events they emitted. Copied into every app decider
+# via +Sync::ClassMethods#inherited+ (registered here, before subclasses exist).
+# The reaction branch passes +events: []+ → no-op. Mirrors Commander#publish_result.
+::Sourced::Decider.after_sync do |events: [], **|
+  events.each { |evt| Sidereal.pubsub.publish(Sidereal.channels.for(evt), evt) }
+rescue StandardError => ex
+  Sidereal.exceptions.report_fatal(exception: ex)
+end
+
+# Projectors: auto-generate + publish a "projected" signal from partition_by.
+::Sourced::Projector.singleton_class.prepend(Sidereal::Integrations::Sourced::ProjectorSignals)

--- a/lib/sidereal/integrations/sourced.rb
+++ b/lib/sidereal/integrations/sourced.rb
@@ -81,14 +81,10 @@ module Sidereal
       end
 
       # Publish the handled command and its dispatched events to Sidereal's
-      # pubsub. Mirrors Sidereal::Dispatcher#publish; runs post-commit via an
-      # :after_sync signal so nothing publishes if the append/delete rolls back.
+      # pubsub. Runs post-commit via an :after_sync signal so nothing publishes
+      # if the append/delete rolls back.
       def publish_result(result)
-        pubsub = Sidereal.config.pubsub
-        pubsub.publish(Sidereal.channels.for(result.msg), result.msg)
-        result.events.each { |evt| pubsub.publish(Sidereal.channels.for(evt), evt) }
-      rescue StandardError => ex
-        Sidereal.exceptions.report_fatal(exception: ex)
+        Integrations::Sourced.publish_messages([result.msg, *result.events])
       end
     end
   end
@@ -103,6 +99,18 @@ module Sidereal
     #   end
     #
     module Sourced
+      # Publish each message to Sidereal's pubsub on its resolved channel. The
+      # single publish body shared by every Sourced→Sidereal path (Commander
+      # action-signal, Decider/Projector after_sync). Publish/resolver failures
+      # are terminal here — the store transaction has already committed, so a
+      # retry would double-apply — hence they funnel to +report_fatal+ rather
+      # than raising into the worker fiber.
+      def self.publish_messages(messages)
+        messages.each { |msg| Sidereal.pubsub.publish(Sidereal.channels.for(msg), msg) }
+      rescue StandardError => ex
+        Sidereal.exceptions.report_fatal(exception: ex)
+      end
+
       # Sidereal only ever calls #append on the store. Delegating to
       # +::Sourced.store+ (rather than capturing it once) means a per-process
       # reconnect — {::Sourced.setup!} re-running the store's configure block
@@ -200,12 +208,9 @@ module Sidereal
 
           after_sync do |**|
             vals = partition_values # instance accessor: the full claimed tuple
-            next if vals.empty? || vals.values.any?(&:nil?)
+            next if vals.empty? || vals.each_value.any?(&:nil?)
 
-            evt = signal.new(payload: vals)
-            Sidereal.pubsub.publish(Sidereal.channels.for(evt), evt)
-          rescue StandardError => ex
-            Sidereal.exceptions.report_fatal(exception: ex)
+            Sidereal::Integrations::Sourced.publish_messages([signal.new(payload: vals)])
           end
         end
       end
@@ -217,11 +222,9 @@ end
 
 # Deciders: publish the domain events they emitted. Copied into every app decider
 # via +Sync::ClassMethods#inherited+ (registered here, before subclasses exist).
-# The reaction branch passes +events: []+ → no-op. Mirrors Commander#publish_result.
+# The reaction branch passes +events: []+ → no-op.
 ::Sourced::Decider.after_sync do |events: [], **|
-  events.each { |evt| Sidereal.pubsub.publish(Sidereal.channels.for(evt), evt) }
-rescue StandardError => ex
-  Sidereal.exceptions.report_fatal(exception: ex)
+  Sidereal::Integrations::Sourced.publish_messages(events)
 end
 
 # Projectors: auto-generate + publish a "projected" signal from partition_by.

--- a/lib/sidereal/integrations/sourced.rb
+++ b/lib/sidereal/integrations/sourced.rb
@@ -2,40 +2,141 @@
 
 # Sourced ⇄ Sidereal integration.
 #
-# +require 'sidereal/integrations/sourced'+ from your boot file to wire a
-# {https://github.com/ismasan/sourced Sourced} backend into Sidereal.
+# +require 'sidereal/integrations/sourced'+ from your boot file to run Sidereal
+# on a {https://github.com/ismasan/sourced Sourced} backend — Sourced becomes a
+# drop-in replacement for Sidereal's built-in store + dispatcher. Sidereal
+# Commanders register and run on the Sourced runtime alongside Sourced Deciders,
+# Projectors and any other reactor; one runtime appends and routes messages to
+# all of them.
+#
+# **Commanders as Sourced reactors.** This file teaches {Sidereal::Commander} the
+# Sourced reactor protocol: each commander is an *exclusive*, id-partitioned,
+# delete-on-ack queue (one partition per command, concurrent, unordered — like
+# Sidereal's worker pool). Its handler runs, dispatched follow-up commands are
+# appended (or scheduled, for +.at+/+.in+), the command + its events are
+# published to {Sidereal.pubsub}, and the handled command is deleted.
 #
 # **Exception bridge.** Registers {Sidereal.exceptions} as a subscriber on
-# Sourced's error strategy, so every Sourced retry / terminal failure is
-# reported to Sidereal's exception registry — which renders the default
-# error toasts and feeds any +on_retry+ / +on_failure+ / +on_fatal+
-# subscribers (e.g. an APM hook). This works because {Sidereal::Exceptions}
-# responds to +#report_retry+ / +#report_failure+, exactly the
-# object-callback interface Sourced's +on_retry+ / +on_fail+ expect. When
-# Sourced is the dispatcher it owns retry/fail orchestration, so Sidereal's
-# own automatic exception reporting never runs — this bridge is what
-# surfaces failures in the UI.
+# Sourced's error strategy, so every Sourced retry / terminal failure surfaces in
+# Sidereal's exception registry (default toasts + +on_retry+/+on_failure+/
+# +on_fatal+ subscribers). When Sourced is the dispatcher it owns retry/fail
+# orchestration, so this bridge is what surfaces failures in the UI.
 #
 # Under the forking Falcon environment each worker loads boot.rb in its own
-# process, so this registration (and Sourced's own store) is established
-# fresh per worker — there is nothing to re-apply across the fork.
+# process, so this registration (and Sourced's own store) is established fresh
+# per worker — there is nothing to re-apply across the fork.
 #
-# Require this at load time (top-level in boot.rb), then point Sidereal at
-# Sourced:
+# Require this at load time (top-level in boot.rb), then apply it with Sidereal's
+# integration hook — one call wires the store + dispatcher together:
 #
 #   require 'sidereal/integrations/sourced'
 #
 #   Sourced.configure { |c| c.store = Sequel.sqlite('db/app.db') }
+#   Sourced.register(SomeDecider)   # deciders/projectors: registered as usual
 #
 #   Sidereal.configure do |c|
-#     c.store      = Sourced.config.store
-#     c.dispatcher = Sourced::Dispatcher
+#     c.use_file_system!                     # pubsub + elector
+#     c.use Sidereal::Integrations::Sourced  # store + dispatcher + error bridge
+#   end
+#
+# Commander-only apps can let the integration configure Sourced's store too:
+#
+#   Sidereal.configure do |c|
+#     c.use_file_system!
+#     c.use Sidereal::Integrations::Sourced, store: Sequel.sqlite('db/app.db')
 #   end
 
 require 'sourced'
 
-# Report Sourced's retry / terminal-failure events to Sidereal's exception
-# registry. Sourced binds these to Sidereal.exceptions#report_retry /
-# #report_failure (the object-callback interface its error strategy accepts).
-Sourced.config.error_strategy.on_retry Sidereal.exceptions
-Sourced.config.error_strategy.on_fail Sidereal.exceptions
+module Sidereal
+  # Teach Commanders the Sourced reactor protocol (duck-typed: Sourced only
+  # needs +handled_messages+ and +handle_claim+; the rest get defaults, but we
+  # override +exclusive?+ so commanders own and delete their command types).
+  class Commander
+    class << self
+      # Commanders exclusively own their command types (Registry enforces one
+      # commander per command) and delete each command on ack.
+      def exclusive? = true
+
+      # The message types this reactor handles (Sourced protocol).
+      def handled_messages = handled_commands
+
+      # Process a claimed batch. For each command: run the commander, then emit
+      # Sourced action signals to (1) append/schedule the dispatched follow-up
+      # commands, (2) publish the command + its events to Sidereal's pubsub after
+      # the store transaction commits, and (3) delete the handled command.
+      def handle_claim(claim)
+        claim.messages.map do |cmd|
+          result = handle(cmd, pubsub: Sidereal.config.pubsub)
+          # build_for splits follow-ups by created_at: immediate :append vs
+          # future :schedule (a .at/.in command carries a future created_at).
+          signals = ::Sourced::Actions.build_for(result.commands, source: cmd)
+          signals << { type: :after_sync, work: -> { publish_result(result) } }
+          signals << { type: :ack, delete: true }
+          [signals, cmd]
+        end
+      end
+
+      # Publish the handled command and its dispatched events to Sidereal's
+      # pubsub. Mirrors Sidereal::Dispatcher#publish; runs post-commit via an
+      # :after_sync signal so nothing publishes if the append/delete rolls back.
+      def publish_result(result)
+        pubsub = Sidereal.config.pubsub
+        pubsub.publish(Sidereal.channels.for(result.msg), result.msg)
+        result.events.each { |evt| pubsub.publish(Sidereal.channels.for(evt), evt) }
+      rescue StandardError => ex
+        Sidereal.exceptions.report_fatal(exception: ex)
+      end
+    end
+  end
+
+  module Integrations
+    # Backend integration wiring Sidereal to Sourced (store + dispatcher). Apply
+    # it in one call via Sidereal's integration hook:
+    #
+    #   Sidereal.configure do |c|
+    #     c.use_file_system!                     # pubsub + elector
+    #     c.use Sidereal::Integrations::Sourced  # store + dispatcher + error bridge
+    #   end
+    #
+    module Sourced
+      # Wire Sidereal's store + dispatcher to Sourced, and bridge Sourced's
+      # retry/failure reporting to Sidereal's exception registry. Called by
+      # {Sidereal::Configuration#use}.
+      #
+      # @param config [Sidereal::Configuration]
+      # @param store [Sequel::Database, nil] when given, configures Sourced's store;
+      #   otherwise the already-configured Sourced store is used.
+      # @return [Sidereal::Configuration]
+      def self.setup(config, store: nil)
+        ::Sourced.configure { |c| c.store = store } if store
+        config.store      = ::Sourced.store # runs Sourced setup! (default in-memory if unconfigured)
+        config.dispatcher = Dispatcher
+
+        # Report Sourced's retry / terminal-failure events to Sidereal's exception
+        # registry (report_retry / report_failure — the object-callback interface
+        # Sourced's error strategy accepts). Since Sourced owns retry/fail
+        # orchestration here, this is what surfaces failures in the UI.
+        ::Sourced.config.error_strategy.on_retry Sidereal.exceptions
+        ::Sourced.config.error_strategy.on_fail Sidereal.exceptions
+        config
+      end
+
+      # Dispatcher factory for +config.dispatcher+. Registers every Sidereal
+      # commander with Sourced (once, with its full command set) and then starts
+      # Sourced's runtime, which routes to commanders, deciders and any reactor.
+      # Registering here (rather than hooking Sidereal.register) means all
+      # +command+ declarations are complete before registration.
+      module Dispatcher
+        # @param task [Async::Task]
+        # @return [Sourced::Dispatcher] the running dispatcher (Host keeps it to #stop)
+        def self.start(task)
+          Sidereal.registry.commanders.each do |commander|
+            ::Sourced.register(commander) unless ::Sourced.router.reactors.include?(commander)
+          end
+          ::Sourced::Dispatcher.start(task)
+        end
+      end
+    end
+  end
+end

--- a/lib/sidereal/integrations/sourced.rb
+++ b/lib/sidereal/integrations/sourced.rb
@@ -24,7 +24,9 @@
 #
 # Under the forking Falcon environment each worker loads boot.rb in its own
 # process, so this registration (and Sourced's own store) is established fresh
-# per worker — there is nothing to re-apply across the fork.
+# per worker. The dispatcher factory also calls {Sourced.setup!} on start,
+# re-establishing connections for the current process — so a *callable* store
+# (below) stays fork-safe even if the app is preloaded in the parent.
 #
 # Require this at load time (top-level in boot.rb), then apply it with Sidereal's
 # integration hook — one call wires the store + dispatcher together:
@@ -39,11 +41,12 @@
 #     c.use Sidereal::Integrations::Sourced  # store + dispatcher + error bridge
 #   end
 #
-# Commander-only apps can let the integration configure Sourced's store too:
+# Commander-only apps can let the integration configure Sourced's store too.
+# Pass a callable factory so each forked worker opens its own connection:
 #
 #   Sidereal.configure do |c|
 #     c.use_file_system!
-#     c.use Sidereal::Integrations::Sourced, store: Sequel.sqlite('db/app.db')
+#     c.use Sidereal::Integrations::Sourced, store: -> { Sequel.sqlite('db/app.db') }
 #   end
 
 require 'sourced'
@@ -100,17 +103,37 @@ module Sidereal
     #   end
     #
     module Sourced
+      # Sidereal only ever calls #append on the store. Delegating to
+      # +::Sourced.store+ (rather than capturing it once) means a per-process
+      # reconnect — {::Sourced.setup!} re-running the store's configure block
+      # after a fork — is picked up automatically, so a forked worker appends
+      # through its own live connection.
+      module StoreProxy
+        module_function
+
+        def append(...) = ::Sourced.store.append(...)
+      end
+
       # Wire Sidereal's store + dispatcher to Sourced, and bridge Sourced's
       # retry/failure reporting to Sidereal's exception registry. Called by
       # {Sidereal::Configuration#use}.
       #
       # @param config [Sidereal::Configuration]
-      # @param store [Sequel::Database, nil] when given, configures Sourced's store;
-      #   otherwise the already-configured Sourced store is used.
+      # @param store [#call, Sequel::Database, nil] when given, configures
+      #   Sourced's store. Prefer a callable factory (e.g.
+      #   +-> { Sequel.sqlite(path) }+): it is registered as a Sourced configure
+      #   block, so {::Sourced.setup!} re-runs it to open a fresh connection per
+      #   process — fork-safe even if the app is preloaded in the parent. A bare
+      #   Sequel::Database is reused as-is (fine when each worker loads its config
+      #   fresh, but not fork-safe under preload). When nil, the already-configured
+      #   Sourced store is used.
       # @return [Sidereal::Configuration]
       def self.setup(config, store: nil)
-        ::Sourced.configure { |c| c.store = store } if store
-        config.store      = ::Sourced.store # runs Sourced setup! (default in-memory if unconfigured)
+        # A Proc is a store factory (re-run per process for fork-safety); a
+        # Sequel::Database is used as-is. (Don't use respond_to?(:call): a
+        # Sequel::Database responds to #call — prepared-statement invocation.)
+        ::Sourced.configure { |c| c.store = store.is_a?(Proc) ? store.call : store } if store
+        config.store      = StoreProxy
         config.dispatcher = Dispatcher
 
         # Report Sourced's retry / terminal-failure events to Sidereal's exception
@@ -131,6 +154,12 @@ module Sidereal
         # @param task [Async::Task]
         # @return [Sourced::Dispatcher] the running dispatcher (Host keeps it to #stop)
         def self.start(task)
+          # Re-establish Sourced's store/connections (and re-register reactors)
+          # for this — possibly just-forked — process before starting. With a
+          # callable store this opens a fresh connection per worker even when the
+          # app was preloaded in the parent; a redundant no-op reconnect when each
+          # worker already loaded its config fresh.
+          ::Sourced.setup!
           Sidereal.registry.commanders.each do |commander|
             ::Sourced.register(commander) unless ::Sourced.router.reactors.include?(commander)
           end

--- a/lib/sidereal/logging.rb
+++ b/lib/sidereal/logging.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'console'
+
+module Sidereal
+  # Silence Async's noisy "Task may have ended with unhandled exception"
+  # WARNINGS for the benign client disconnects that are constant in an
+  # SSE-streaming app.
+  #
+  # When a browser drops its +/updates+ connection, async-http's server task
+  # (and Datastar's stream teardown) raise +Errno::EPIPE+ ("Broken pipe") while
+  # writing the next chunk to the now-dead socket. Async logs any task that ends
+  # on an unhandled exception at +:warn+, so the log fills with these on every
+  # disconnect.
+  #
+  # Datastar's AsyncExecutor tries to suppress this with
+  # +Console.logger.disable(Async::Task)+, but the Console logger is
+  # fiber/thread-local (via the +fiber-local+ gem), so a one-off disable on the
+  # boot fiber doesn't reliably reach async-http's connection tasks. Instead we
+  # hook the single method the console gem uses to build *every* logger
+  # (+Console::Config#make_logger+), disabling the subject on each one — on any
+  # thread or fiber. This is the same effect as a project-level
+  # +config/console.rb+, but shipped in the gem so every Sidereal app gets it for
+  # free.
+  #
+  # Set +CONSOLE_LEVEL=debug+ (or +=info+) in the environment to re-enable full
+  # output while debugging.
+  module Logging
+    # Prepended onto {Console::Config} so it wraps logger construction. Works
+    # even though +Console::Config::DEFAULT+ is already frozen — freezing the
+    # instance doesn't stop method resolution from walking the prepend.
+    module DisableAsyncTaskWarnings
+      def make_logger(...)
+        super.tap do |logger|
+          # Async::Task may be undefined when the first logger is built during
+          # +require "console"+; it is loaded by the time serving loggers are
+          # created, which are the ones that matter.
+          logger.disable(::Async::Task) if defined?(::Async::Task)
+        end
+      end
+    end
+
+    module_function
+
+    # Install the global filter. Idempotent — safe to call more than once.
+    #
+    # @return [void]
+    def quiet_async_disconnect_warnings!
+      return if ::Console::Config.include?(DisableAsyncTaskWarnings)
+
+      ::Console::Config.prepend(DisableAsyncTaskWarnings)
+      # make_logger only affects loggers built from here on, so also disable on
+      # the current thread's logger in case it was already created (and the
+      # reactor ends up serving on this thread).
+      ::Console.logger.disable(::Async::Task) if defined?(::Async::Task)
+    end
+  end
+end
+
+Sidereal::Logging.quiet_async_disconnect_warnings!

--- a/lib/sidereal/pubsub/memory.rb
+++ b/lib/sidereal/pubsub/memory.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'singleton'
+require 'sidereal/single_process'
 require_relative 'pattern'
 
 module Sidereal
@@ -12,6 +13,7 @@ module Sidereal
     # See {Pattern} for the wildcard subscription rules.
     class Memory
       include Singleton
+      include SingleProcess
 
       public_class_method :new
 

--- a/lib/sidereal/registry.rb
+++ b/lib/sidereal/registry.rb
@@ -23,6 +23,10 @@ module Sidereal
 
     def [](cmd_class) = @table[cmd_class]
 
+    # The distinct commander classes registered, in first-seen order.
+    # @return [Array<Class>]
+    def commanders = @table.values.uniq
+
     def clear
       @table.clear
       self

--- a/lib/sidereal/scheduler.rb
+++ b/lib/sidereal/scheduler.rb
@@ -310,7 +310,13 @@ module Sidereal
     def spawn_tick_fiber(task)
       return if @tick_fiber
 
-      @tick_fiber = task.async do
+      # Transient, like the elector's election fiber and the pubsub's
+      # client fiber: an infinite-loop child must not keep the parent
+      # task alive, or the process can't shut down — and on the FS
+      # backend a lingering process holds the leader flock, blocking
+      # the next boot's election. It dies with the task like the other
+      # subsystem fibers (see Host#start).
+      @tick_fiber = task.async(transient: true) do
         loop do
           tick
           sleep @tick_interval

--- a/lib/sidereal/single_process.rb
+++ b/lib/sidereal/single_process.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Sidereal
+  # Marker for subsystem implementations whose state lives entirely within one
+  # process — in-memory queues ({Store::Memory}, {PubSub::Memory}) and
+  # always-leader election ({Elector::AlwaysLeader}). They are correct for a
+  # single-process deployment but silently break cross-process fan-out once the
+  # host forks multiple workers: an SSE update published in one worker never
+  # reaches subscribers connected to another, and every process believes it is
+  # the leader.
+  #
+  # {Sidereal.warn_unsafe_topology} uses this marker to warn loudly at startup
+  # when any such subsystem is configured alongside a multi-process deployment.
+  # Cross-process-safe implementations (the Unix-socket pubsub, the FileSystem
+  # elector/store, a DB-backed Sourced store) deliberately do NOT include it.
+  module SingleProcess
+  end
+end

--- a/lib/sidereal/store/memory.rb
+++ b/lib/sidereal/store/memory.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require 'singleton'
+require 'sidereal/single_process'
 
 module Sidereal
   module Store
     class Memory
       include Singleton
+      include SingleProcess
 
       public_class_method :new
 

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -24,4 +24,65 @@ RSpec.describe Sidereal::Configuration do
       expect { config.use(Object.new) }.to raise_error(StandardError)
     end
   end
+
+  describe '#single_process_subsystems' do
+    # Cross-process-safe stand-ins: satisfy the config interfaces but carry no
+    # SingleProcess marker (like the Unix pubsub / FileSystem elector+store).
+    let(:safe_store)   { double('store', append: nil) }
+    let(:safe_pubsub)  { double('pubsub', start: nil, subscribe: nil, publish: nil) }
+    let(:safe_elector) { double('elector', start: nil, on_promote: nil, on_demote: nil, leader?: true) }
+
+    it 'lists the in-process defaults (Memory store + pubsub, AlwaysLeader elector)' do
+      config = described_class.new # defaults are all in-process
+      expect(config.single_process_subsystems).to contain_exactly('store', 'pubsub', 'elector')
+    end
+
+    it 'is empty once every subsystem is cross-process safe' do
+      config = described_class.new
+      config.store = safe_store
+      config.pubsub = safe_pubsub
+      config.elector = safe_elector
+      expect(config.single_process_subsystems).to be_empty
+    end
+
+    it 'flags only the subsystems still in-process (e.g. pubsub swapped, elector not)' do
+      config = described_class.new
+      config.pubsub = safe_pubsub
+      expect(config.single_process_subsystems).to contain_exactly('store', 'elector')
+    end
+  end
+end
+
+RSpec.describe 'Sidereal.check_topology!' do
+  # Inject a config so the process-global one is never touched.
+  let(:in_process_config) { Sidereal::Configuration.new } # all-in-process defaults
+  let(:safe_config) do
+    Sidereal::Configuration.new.tap do |c|
+      c.store = double('store', append: nil)
+      c.pubsub = double('pubsub', start: nil, subscribe: nil, publish: nil)
+      c.elector = double('elector', start: nil, on_promote: nil, on_demote: nil, leader?: true)
+    end
+  end
+
+  it 'returns without erroring or exiting for a single worker' do
+    expect(Console).not_to receive(:error)
+    expect { Sidereal.check_topology!(1, config: in_process_config) }.not_to raise_error
+  end
+
+  it 'logs a loud multi-line error and exits when in-process subsystems meet multiple workers' do
+    expect(Console).to receive(:error) do |_source, message, **meta|
+      expect(message).to include('Refusing to boot')
+      expect(message).to include('use_file_system!')
+      expect(message.lines.size).to be > 1                 # multi-line description
+      expect(meta[:subsystems]).to contain_exactly('store', 'pubsub', 'elector')
+      expect(meta[:process_count]).to eq(3)
+    end
+    expect { Sidereal.check_topology!(3, config: in_process_config) }
+      .to raise_error(SystemExit) { |e| expect(e.status).to eq(1) }
+  end
+
+  it 'does nothing when every subsystem is cross-process safe' do
+    expect(Console).not_to receive(:error)
+    expect { Sidereal.check_topology!(8, config: safe_config) }.not_to raise_error
+  end
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Sidereal::Configuration do
+  describe '#use' do
+    it 'applies an integration via #setup(config, **opts) and returns self' do
+      received = nil
+      integration = Object.new
+      integration.define_singleton_method(:setup) do |config, **opts|
+        received = [config, opts]
+        config
+      end
+
+      config = described_class.new
+      result = config.use(integration, foo: 1, bar: 2)
+
+      expect(result).to be(config)
+      expect(received).to eq([config, { foo: 1, bar: 2 }])
+    end
+
+    it 'raises for an object that does not respond to #setup' do
+      config = described_class.new
+      expect { config.use(Object.new) }.to raise_error(StandardError)
+    end
+  end
+end

--- a/spec/integrations/file_system_spec.rb
+++ b/spec/integrations/file_system_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tmpdir'
+require 'sidereal/integrations/file_system'
+
+RSpec.describe Sidereal::Integrations::FileSystem do
+  let(:config) { Sidereal::Configuration.new }
+
+  describe '.setup' do
+    it 'wires the store/pubsub/elector to the filesystem + unix-socket impls' do
+      Dir.mktmpdir do |dir|
+        described_class.setup(config, dir: dir)
+
+        expect(config.store).to be_a(Sidereal::Store::FileSystem)
+        expect(config.pubsub).to be_a(Sidereal::PubSub::Unix)
+        expect(config.elector).to be_a(Sidereal::Elector::FileSystem)
+      end
+    end
+
+    it 'places files, socket, and lock under dir' do
+      Dir.mktmpdir do |dir|
+        described_class.setup(config, dir: dir)
+
+        # Appending a command creates the store tree under <dir>/store.
+        config.store.append(Sidereal::Message.define('intg_fs.ping').new)
+
+        expect(Dir.exist?(File.join(dir, 'store'))).to be true
+      end
+    end
+
+    it 'defaults dir to ./storage' do
+      expect(Sidereal::Store::FileSystem).to receive(:new)
+        .with(root: File.join('storage', 'store'))
+        .and_return(double('store', append: nil))
+      expect(Sidereal::PubSub::Unix).to receive(:new)
+        .with(socket_path: File.join('storage', 'pubsub.sock'))
+        .and_return(double('pubsub', start: nil, subscribe: nil, publish: nil))
+      expect(Sidereal::Elector::FileSystem).to receive(:new)
+        .with(lock_path: File.join('storage', 'leader.lock'))
+        .and_return(double('elector', start: nil, on_promote: nil, on_demote: nil, leader?: true))
+
+      described_class.setup(config)
+    end
+
+    it 'returns the config' do
+      Dir.mktmpdir do |dir|
+        expect(described_class.setup(config, dir: dir)).to be(config)
+      end
+    end
+  end
+
+  describe 'applied via Configuration#use' do
+    it 'wires the collaborators and returns self' do
+      Dir.mktmpdir do |dir|
+        result = config.use(described_class, dir: dir)
+
+        expect(result).to be(config)
+        expect(config.store).to be_a(Sidereal::Store::FileSystem)
+        expect(config.pubsub).to be_a(Sidereal::PubSub::Unix)
+        expect(config.elector).to be_a(Sidereal::Elector::FileSystem)
+      end
+    end
+  end
+end

--- a/spec/integrations/sourced_spec.rb
+++ b/spec/integrations/sourced_spec.rb
@@ -72,6 +72,14 @@ RSpec.describe 'Sidereal::Commander on the Sourced runtime' do
     router.register(IntgCommander)
   end
 
+  after do
+    # These specs open in-memory SQLite via Sequel; Sequel::DATABASES keeps a
+    # global ref so the connection stays open. Close them after each example so
+    # the fork-based specs (pubsub/unix_failover, store/file_system) don't inherit
+    # a live SQLite connection and trip sqlite3's fork-safety warning.
+    Sequel::DATABASES.each(&:disconnect)
+  end
+
   it 'registers a Commander as an exclusive, id-partitioned Sourced reactor' do
     expect(IntgCommander.exclusive?).to be true
     expect(IntgCommander.handled_messages).to include(IntgDoThing, IntgDoNext)

--- a/spec/integrations/sourced_spec.rb
+++ b/spec/integrations/sourced_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'sourced'
+require 'sourced/store'
+require 'sequel'
+require 'sidereal/integrations/sourced'
+
+# -- Test messages --
+
+IntgDoThing = Sidereal::Message.define('intg.do_thing') do
+  attribute :n, Sidereal::Types::Integer
+end
+
+IntgScheduleThing = Sidereal::Message.define('intg.schedule_thing') do
+  attribute :n, Sidereal::Types::Integer
+end
+
+IntgDoNext = Sidereal::Message.define('intg.do_next') do
+  attribute :n, Sidereal::Types::Integer
+end
+
+IntgThingHappened = Sidereal::Message.define('intg.thing_happened') do
+  attribute :n, Sidereal::Types::Integer
+end
+
+class IntgCommander < Sidereal::Commander
+  command IntgDoThing do |cmd|
+    dispatch IntgDoNext, n: cmd.payload.n          # follow-up command (in registry)
+    dispatch IntgThingHappened, n: cmd.payload.n   # event (not in registry) -> Result.events
+  end
+
+  command IntgScheduleThing do |cmd|
+    dispatch(IntgDoNext, n: cmd.payload.n).in(3600) # delayed follow-up
+  end
+
+  command IntgDoNext do |_cmd|
+    # terminal, no-op
+  end
+end
+
+class IntgFakePubSub
+  attr_reader :published
+
+  def initialize
+    @published = []
+  end
+
+  def start(_task) = self
+  def subscribe(_pattern) = nil
+
+  def publish(channel, message)
+    @published << { channel: channel, message: message }
+    self
+  end
+end
+
+RSpec.describe 'Sidereal::Commander on the Sourced runtime' do
+  let(:db) { Sequel.sqlite }
+  let(:store) { Sourced::Store.new(db) }
+  let(:router) { Sourced::Router.new(store: store) }
+  let(:pubsub) { IntgFakePubSub.new }
+
+  around do |example|
+    original = Sidereal.config.pubsub
+    Sidereal.config.pubsub = pubsub
+    example.run
+    Sidereal.config.pubsub = original
+  end
+
+  before do
+    store.install!
+    router.register(IntgCommander)
+  end
+
+  it 'registers a Commander as an exclusive, id-partitioned Sourced reactor' do
+    expect(IntgCommander.exclusive?).to be true
+    expect(IntgCommander.handled_messages).to include(IntgDoThing, IntgDoNext)
+
+    row = db[:sourced_consumer_groups].where(group_id: 'IntgCommander').first
+    expect(JSON.parse(row[:partition_by])).to eq(['__id'])
+  end
+
+  describe 'config.use(Sidereal::Integrations::Sourced)' do
+    after { Sourced.reset! }
+
+    it 'wires the store + dispatcher together in one call' do
+      config = Sidereal::Configuration.new
+      config.use(Sidereal::Integrations::Sourced, store: Sequel.sqlite)
+
+      expect(config.store).to be(Sourced.config.store)
+      expect(config.dispatcher).to be(Sidereal::Integrations::Sourced::Dispatcher)
+    end
+
+    it 'wires Sourced retry/fail reporting to Sidereal.exceptions' do
+      strategy = Sourced.config.error_strategy
+      expect(strategy).to receive(:on_retry).with(Sidereal.exceptions)
+      expect(strategy).to receive(:on_fail).with(Sidereal.exceptions)
+
+      Sidereal::Configuration.new.use(Sidereal::Integrations::Sourced, store: Sequel.sqlite)
+    end
+  end
+
+  it 'handles a command: deletes it, appends the follow-up, publishes msg + events' do
+    store.append(IntgDoThing.new(payload: { n: 1 }))
+
+    expect(router.handle_next_for(IntgCommander)).to be true
+
+    # handled command deleted (queue semantics)
+    expect(db[:sourced_messages].where(message_type: 'intg.do_thing').count).to eq(0)
+    # dispatched follow-up command appended
+    expect(db[:sourced_messages].where(message_type: 'intg.do_next').count).to eq(1)
+    # command + event published to Sidereal pubsub after commit
+    published_types = pubsub.published.map { |p| p[:message].type }
+    expect(published_types).to include('intg.do_thing', 'intg.thing_happened')
+
+    # the follow-up command is itself claimable (id-indexed) and processed next
+    expect(router.handle_next_for(IntgCommander)).to be true
+    expect(db[:sourced_messages].count).to eq(0)
+  end
+
+  it 'schedules a delayed follow-up command (.in/.at) into scheduled_messages' do
+    store.append(IntgScheduleThing.new(payload: { n: 2 }))
+
+    expect(router.handle_next_for(IntgCommander)).to be true
+
+    expect(db[:sourced_messages].where(message_type: 'intg.schedule_thing').count).to eq(0)
+    expect(db[:sourced_messages].where(message_type: 'intg.do_next').count).to eq(0) # not appended yet
+    expect(db[:sourced_scheduled_messages].count).to eq(1)                            # scheduled instead
+  end
+end

--- a/spec/integrations/sourced_spec.rb
+++ b/spec/integrations/sourced_spec.rb
@@ -266,13 +266,7 @@ RSpec.describe 'Sidereal::Commander on the Sourced runtime' do
     before { Sidereal.reset_channels! }
     after  { Sidereal.reset_channels! }
 
-    it 'defines a Projected signal from a single partition key' do
-      expect(IntgThingProjector.const_defined?(:Projected, false)).to be true
-
-      evt = IntgThingProjector::Projected.new(payload: { thing_id: 't1' })
-      expect(evt.payload.thing_id).to eq('t1')
-    end
-
+    # Auto-defines MyProjector::Projected (single key) and publishes it end-to-end.
     it 'publishes the Projected signal on the resolved channel after a batch' do
       Sidereal.channels.channel_name(IntgThingProjector::Projected) { |m| "things.#{m.payload.thing_id}" }
 
@@ -288,12 +282,9 @@ RSpec.describe 'Sidereal::Commander on the Sourced runtime' do
     end
 
     it 'carries every key for a multi-key partition (partition_values, not read-model state)' do
-      # The projector's evolve only writes student_id into state — the signal
-      # still carries BOTH keys, proving the payload comes from partition_values.
-      expect(IntgEnrollmentProjector.const_defined?(:Projected, false)).to be true
-      schema_evt = IntgEnrollmentProjector::Projected.new(payload: { student_id: 's1', course_id: 'c1' })
-      expect(schema_evt.payload.to_h).to include(student_id: 's1', course_id: 'c1')
-
+      # The projector's evolve only writes student_id into state — the published
+      # signal still carries BOTH keys, proving the payload comes from
+      # partition_values rather than read-model state.
       Sidereal.channels.channel_name(IntgEnrollmentProjector::Projected) do |m|
         "enroll.#{m.payload.student_id}.#{m.payload.course_id}"
       end

--- a/spec/integrations/sourced_spec.rb
+++ b/spec/integrations/sourced_spec.rb
@@ -3,7 +3,6 @@
 require 'spec_helper'
 require 'sourced'
 require 'sourced/store'
-require 'sequel'
 require 'sidereal/integrations/sourced'
 
 # -- Test messages --
@@ -84,12 +83,19 @@ RSpec.describe 'Sidereal::Commander on the Sourced runtime' do
   describe 'config.use(Sidereal::Integrations::Sourced)' do
     after { Sourced.reset! }
 
-    it 'wires the store + dispatcher together in one call' do
+    it 'wires the dispatcher and a store proxy over the current Sourced store' do
       config = Sidereal::Configuration.new
       config.use(Sidereal::Integrations::Sourced, store: Sequel.sqlite)
 
-      expect(config.store).to be(Sourced.config.store)
       expect(config.dispatcher).to be(Sidereal::Integrations::Sourced::Dispatcher)
+
+      # config.store delegates #append to whatever Sourced.store is at call time,
+      # so a per-worker reconnect is picked up without re-pointing the config.
+      expect(config.store).to be(Sidereal::Integrations::Sourced::StoreProxy)
+      fake = double('sourced store')
+      allow(Sourced).to receive(:store).and_return(fake)
+      expect(fake).to receive(:append).with(:msg).and_return(:ok)
+      expect(config.store.append(:msg)).to eq(:ok)
     end
 
     it 'wires Sourced retry/fail reporting to Sidereal.exceptions' do
@@ -98,6 +104,32 @@ RSpec.describe 'Sidereal::Commander on the Sourced runtime' do
       expect(strategy).to receive(:on_fail).with(Sidereal.exceptions)
 
       Sidereal::Configuration.new.use(Sidereal::Integrations::Sourced, store: Sequel.sqlite)
+    end
+
+    it 'is fork-safe: a callable store yields a fresh connection when Sourced re-establishes' do
+      Sidereal::Configuration.new.use(
+        Sidereal::Integrations::Sourced,
+        store: -> { Sequel.sqlite }
+      )
+      store1 = Sourced.store
+
+      # Sourced.setup! re-runs the store's configure block (what the dispatcher
+      # factory does per worker) — a bare connection would be reused, a factory
+      # opens a new one.
+      Sourced.setup!
+
+      expect(Sourced.store).not_to be(store1)
+    end
+  end
+
+  describe 'Sidereal::Integrations::Sourced::Dispatcher.start' do
+    it 're-establishes connections (Sourced.setup!) before starting the Sourced runtime' do
+      task = double('task')
+      allow(Sidereal.registry).to receive(:commanders).and_return([])
+      expect(Sourced).to receive(:setup!).ordered
+      expect(Sourced::Dispatcher).to receive(:start).with(task).ordered.and_return(:running)
+
+      expect(Sidereal::Integrations::Sourced::Dispatcher.start(task)).to eq(:running)
     end
   end
 

--- a/spec/integrations/sourced_spec.rb
+++ b/spec/integrations/sourced_spec.rb
@@ -3,6 +3,7 @@
 require 'spec_helper'
 require 'sourced'
 require 'sourced/store'
+require 'sourced/testing/rspec'
 require 'sidereal/integrations/sourced'
 
 # -- Test messages --
@@ -51,6 +52,70 @@ class IntgFakePubSub
   def publish(channel, message)
     @published << { channel: channel, message: message }
     self
+  end
+end
+
+# -- Test Sourced reactors (Decider + Projectors) exercising the integration's
+#    auto-publish hooks. Defined after `require 'sidereal/integrations/sourced'`,
+#    so the Decider inherits the injected after_sync and the Projectors trigger
+#    the partition_by signal-generation hook. --
+
+class IntgWidget < Sourced::Decider
+  consumer_group 'intg_widget'
+  partition_by :widget_id
+
+  Create  = Sourced::Command.define('intg_widget.create') { attribute :widget_id, Sourced::Types::String }
+  Created = Sourced::Event.define('intg_widget.created')  { attribute :widget_id, Sourced::Types::String }
+
+  state do |init|
+    { widget_id: init[:widget_id], created: false }
+  end
+
+  evolve(Created) do |state, _evt|
+    state[:created] = true
+  end
+
+  command(Create) do |_state, cmd|
+    event Created, widget_id: cmd.payload.widget_id
+  end
+end
+
+IntgThingHappenedEvt = Sourced::Event.define('intg.thing_happened_evt') do
+  attribute :thing_id, Sourced::Types::String
+end
+
+# Single partition key.
+class IntgThingProjector < Sourced::Projector::StateStored
+  consumer_group 'intg_thing_projector'
+  partition_by :thing_id
+
+  state do |values|
+    { thing_id: values[:thing_id] }
+  end
+
+  evolve(IntgThingHappenedEvt) do |state, evt|
+    state[:thing_id] = evt.payload.thing_id
+  end
+end
+
+IntgEnrolledEvt = Sourced::Event.define('intg.enrolled') do
+  attribute :student_id, Sourced::Types::String
+  attribute :course_id, Sourced::Types::String
+end
+
+# Multiple partition keys (student_id + course_id).
+class IntgEnrollmentProjector < Sourced::Projector::StateStored
+  consumer_group 'intg_enrollment_projector'
+  partition_by :student_id, :course_id
+
+  # Deliberately keeps course_id OUT of state — the Projected signal must
+  # still carry it (sourced from partition_values, not read-model state).
+  state do |values|
+    { student_id: values[:student_id] }
+  end
+
+  evolve(IntgEnrolledEvt) do |state, evt|
+    state[:student_id] = evt.payload.student_id
   end
 end
 
@@ -167,5 +232,80 @@ RSpec.describe 'Sidereal::Commander on the Sourced runtime' do
     expect(db[:sourced_messages].where(message_type: 'intg.schedule_thing').count).to eq(0)
     expect(db[:sourced_messages].where(message_type: 'intg.do_next').count).to eq(0) # not appended yet
     expect(db[:sourced_scheduled_messages].count).to eq(1)                            # scheduled instead
+  end
+
+  # -- Auto-publish injected by the Sourced integration --
+
+  describe 'Sourced::Decider auto-publishes emitted events' do
+    include Sourced::Testing::RSpec
+
+    # Register resolvers on the global channels registry; reset around each
+    # example so nothing leaks (and so a booted Host's lock never bites here).
+    before { Sidereal.reset_channels! }
+    after  { Sidereal.reset_channels! }
+
+    it 'publishes each emitted event via Sidereal.channels.for — with no manual after_sync' do
+      Sidereal.channels.channel_name(IntgWidget::Created) { |m| "widgets.#{m.payload.widget_id}" }
+
+      # .then! (no block) runs Sync/AfterSync exactly once.
+      with_reactor(IntgWidget, widget_id: 'w1')
+        .when(IntgWidget::Create, widget_id: 'w1')
+        .then!(IntgWidget::Created, widget_id: 'w1')
+
+      expect(pubsub.published.size).to eq(1)
+      entry = pubsub.published.first
+      expect(entry[:channel]).to eq('widgets.w1')
+      expect(entry[:message]).to be_a(IntgWidget::Created)
+      expect(entry[:message].payload.widget_id).to eq('w1')
+    end
+  end
+
+  describe 'Sourced::Projector auto-generates + publishes a Projected signal' do
+    include Sourced::Testing::RSpec
+
+    before { Sidereal.reset_channels! }
+    after  { Sidereal.reset_channels! }
+
+    it 'defines a Projected signal from a single partition key' do
+      expect(IntgThingProjector.const_defined?(:Projected, false)).to be true
+
+      evt = IntgThingProjector::Projected.new(payload: { thing_id: 't1' })
+      expect(evt.payload.thing_id).to eq('t1')
+    end
+
+    it 'publishes the Projected signal on the resolved channel after a batch' do
+      Sidereal.channels.channel_name(IntgThingProjector::Projected) { |m| "things.#{m.payload.thing_id}" }
+
+      with_reactor(IntgThingProjector, thing_id: 't1')
+        .when(IntgThingHappenedEvt, thing_id: 't1')
+        .then!([])
+
+      expect(pubsub.published.size).to eq(1)
+      entry = pubsub.published.first
+      expect(entry[:channel]).to eq('things.t1')
+      expect(entry[:message]).to be_a(IntgThingProjector::Projected)
+      expect(entry[:message].payload.thing_id).to eq('t1')
+    end
+
+    it 'carries every key for a multi-key partition (partition_values, not read-model state)' do
+      # The projector's evolve only writes student_id into state — the signal
+      # still carries BOTH keys, proving the payload comes from partition_values.
+      expect(IntgEnrollmentProjector.const_defined?(:Projected, false)).to be true
+      schema_evt = IntgEnrollmentProjector::Projected.new(payload: { student_id: 's1', course_id: 'c1' })
+      expect(schema_evt.payload.to_h).to include(student_id: 's1', course_id: 'c1')
+
+      Sidereal.channels.channel_name(IntgEnrollmentProjector::Projected) do |m|
+        "enroll.#{m.payload.student_id}.#{m.payload.course_id}"
+      end
+
+      with_reactor(IntgEnrollmentProjector, student_id: 's1', course_id: 'c1')
+        .when(IntgEnrolledEvt, student_id: 's1', course_id: 'c1')
+        .then!([])
+
+      expect(pubsub.published.size).to eq(1)
+      entry = pubsub.published.first
+      expect(entry[:channel]).to eq('enroll.s1.c1')
+      expect(entry[:message].payload.to_h).to include(student_id: 's1', course_id: 'c1')
+    end
   end
 end

--- a/spec/logging_spec.rb
+++ b/spec/logging_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'console'
+require 'async'
+
+RSpec.describe Sidereal::Logging do
+  it 'disables Async::Task warnings on every logger the console gem builds' do
+    # A brand-new logger (what a fresh serving thread/fiber would get) comes out
+    # with Async::Task disabled — no dependency on the current fiber's logger.
+    logger = Console::Config::DEFAULT.make_logger($stderr)
+    expect(logger.enabled?(Async::Task)).to be false
+  end
+
+  it 'is prepended onto Console::Config exactly once and is idempotent' do
+    described_class.quiet_async_disconnect_warnings!
+    described_class.quiet_async_disconnect_warnings!
+
+    installs = Console::Config.ancestors.count { |m| m == described_class::DisableAsyncTaskWarnings }
+    expect(installs).to eq(1)
+  end
+end

--- a/spec/registry_spec.rb
+++ b/spec/registry_spec.rb
@@ -41,4 +41,31 @@ RSpec.describe Sidereal::Registry do
     expect(registry[RegistryCmdA]).to be_nil
     expect(registry[RegistryCmdB]).to be_nil
   end
+
+  describe '#commanders' do
+    it 'is empty for a fresh registry' do
+      expect(registry.commanders).to eq([])
+    end
+
+    it 'returns the distinct commander classes in first-seen order' do
+      registry[RegistryCmdA] = commander_a
+      registry[RegistryCmdB] = commander_b
+
+      expect(registry.commanders).to eq([commander_a, commander_b])
+    end
+
+    it 'de-duplicates a commander that handles more than one command' do
+      registry[RegistryCmdA] = commander_a
+      registry[RegistryCmdB] = commander_a
+
+      expect(registry.commanders).to eq([commander_a])
+    end
+
+    it 'reflects clear' do
+      registry[RegistryCmdA] = commander_a
+      registry.clear
+
+      expect(registry.commanders).to eq([])
+    end
+  end
 end

--- a/spec/scheduler_spec.rb
+++ b/spec/scheduler_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'timeout'
 
 # Test message classes used by the step-based Scheduler tests below.
 TestSchedFirst  = Sidereal::Message.define('test.sched_first')
@@ -383,6 +384,38 @@ RSpec.describe Sidereal::Scheduler do
       end
 
       expect(store.appended.count { |m| m.is_a?(TestSchedRun) }).to be >= 1
+    end
+
+    it 'spawns the tick fiber as a transient child that does not block task teardown' do
+      # Regression: a non-transient tick fiber keeps its parent task alive, so
+      # the process never shuts down — and on the FileSystem backend a lingering
+      # process holds the leader flock, blocking the next boot's election. Here
+      # we start the scheduler under a leader (so the tick fiber is spawned and
+      # looping) and then let the Sync block reach its end WITHOUT calling
+      # task.stop. With a transient tick fiber the block tears down promptly; a
+      # non-transient one would hang until Timeout fires the failure.
+      elector = Class.new do
+        include Sidereal::Elector::Callbacks
+        def initialize = @leader = true
+        def leader? = @leader
+        def start(_task) = self
+      end.new
+
+      sched = described_class.new(tick_interval: 0.02, store: store, elector: elector)
+      sched.schedule('Tick') { |sc| sc.at '* * * * * *', TestSchedRun, n: 1 }
+
+      # A transient tick fiber lets the Sync block tear down on its own; a
+      # non-transient one keeps the task alive forever, so Timeout fires and
+      # this raises. The assertion is "teardown completed without timing out".
+      expect do
+        Timeout.timeout(5) do
+          Sync do |task|
+            sched.start(task) # leader? == true -> tick fiber spawns immediately
+            sleep 0.1         # let it loop a few times
+            # no task.stop: only the transient tick fiber remains as a child
+          end
+        end
+      end.not_to raise_error
     end
   end
 


### PR DESCRIPTION
## What

- **New integration API** — `Sidereal::Configuration#use(integration, **opts)`, validated by a new `IntegrationInterface` (`Types::Interface[:setup]`). An integration self-applies to a `Configuration` via `#setup(config, **opts)`.
- **`Sidereal::Integrations::Sourced`** — run Sidereal on a [Sourced](https://github.com/ismasan/sourced) backend: Sourced becomes a drop-in store + dispatcher, Sidereal Commanders register as Sourced reactors (exclusive, id-partitioned, delete-on-ack), and Sourced retry/failure reporting is bridged into `Sidereal.exceptions`. Takes a lazy/callable store and calls `Sourced.setup!` after fork so each worker gets its own connection.
- **Auto-publish for Sourced reactors** — Sourced Deciders and Projectors now push their changes to Sidereal's pubsub automatically, so Pages re-render over SSE without any hand-written bridge code. Previously every reactor needed a manual `after_sync` block calling `Sidereal.pubsub.publish`; those are all removed from the example apps.
- **`Sidereal::Integrations::FileSystem`** — `Configuration#use_file_system!` is now a thin wrapper that installs this integration (store + unix-socket pubsub + file-lock elector under a dir).
- **Scheduler fix** — the tick fiber is now spawned `transient: true`, so it dies with its parent task instead of keeping the process alive.
- **Multi-process safety check** — a forking host that runs multiple workers but still has in-process-only subsystems configured (Memory store/pubsub, AlwaysLeader elector) now **fails fast** at boot with a loud, multi-line error and exits, instead of silently serving an app whose SSE updates never cross processes.
- **Quieter SSE-disconnect logs** — the benign `Errno::EPIPE` "Broken pipe" warnings Async logs when a browser drops its `/updates` connection are suppressed globally, so the log isn't flooded on every disconnect. Every Sidereal app gets this for free.
- **Example apps** — `examples/chat` and `examples/chess` now run on the Sourced backend; `examples/sourced_donations` uses the new `use` hook.

## Setup

Both backends install through the new `#use` hook and compose — FileSystem supplies cross-process pubsub + leader election, Sourced supplies the event store + dispatcher:

```ruby
# boot.rb — loaded fresh in each forked Falcon worker
# Add sourced to your Gemfile
require 'sidereal/integrations/sourced'

require_relative 'domain/campaign'            # a Sourced::Decider
require_relative 'domain/campaigns_projector' # a Sourced::Projector

Sourced.register(Campaign)
Sourced.register(CampaignsProjector)

Sidereal.configure do |c|
  # FileSystem backend: cross-process pubsub (unix socket) + leader election
  # (file lock), both under ./storage. Needed whenever workers > 1 so SSE
  # updates fan out across processes via a single elected broker.
  c.use_file_system!

  # Sourced backend: use Sourced's event store + dispatcher (it overrides the
  # FS store, keeps the FS pubsub/elector). Pass a *callable* store so each
  # forked worker opens its own SQLite connection — Sourced.setup! re-runs it
  # post-fork. This one call also bridges Sourced retry/failure reporting into
  # Sidereal.exceptions.
  c.use Sidereal::Integrations::Sourced, store: -> { Sequel.sqlite('storage/app.db') }
end
```

That's the whole wiring: no manual store/pubsub/dispatcher assignment, and — thanks to the auto-publish hooks below — no per-reactor `after_sync` bridge code. `Campaign`'s events and `CampaignsProjector`'s updates reach subscribed Pages over SSE automatically. (If you'd rather configure Sourced's store yourself via `Sourced.configure { ... }`, drop the `store:` arg and `use Sidereal::Integrations::Sourced` alone — that's what `examples/sourced_donations` does.)

## Why

- The store/pubsub/elector/dispatcher were wired piecemeal; `#use` gives third-party runtimes (Sourced today, others later) a single, uniform way to configure Sidereal as their front end, and makes `use_file_system!` just one integration among several.
- Sidereal Commanders already auto-publish their command + events after handling (so the UI reacts). Sourced Deciders/Projectors did not — apps had to hand-write an `after_sync` publishing block in **every** reactor, and Projectors additionally had to define their own "I've been updated" event class and hand-compose a channel string. That's boilerplate, easy to get wrong, and easy to forget on a new reactor. Making it automatic in the integration layer means the UI stays live by default.
- The scheduler's tick fiber was **non-transient**, so it kept its parent task alive forever. The process never shut down cleanly, and on the FileSystem backend a lingering process kept holding the leader flock — so the next boot couldn't elect a leader and scheduled commands silently never fired. Making it transient (matching the elector/pubsub fibers) fixes clean shutdown and reliable re-election.
- Running `count > 1` workers with the default in-process store/pubsub/elector is a silent footgun: each worker gets its own in-memory queue and every worker thinks it's the leader, so an update handled in one worker never reaches a browser connected to another — the app *looks* fine but never updates live. This cost real debugging time on a demo app, so Sidereal now refuses to boot into that topology and tells you exactly how to fix it.
- Sidereal is an SSE framework, so clients dropping their `/updates` connection is constant and normal — but each disconnect leaves async-http mid-write to a dead socket, raising `Errno::EPIPE` in its server task, which Async logs at `:warn`. That noise buried the real logs. Datastar tries to suppress it, but its mechanism is fiber/thread-local and unreliable under the Falcon reactor.

## How

- `#use` calls `IntegrationInterface.parse(integration).setup(self, **opts)` and returns `self`, so it composes in or out of a `Sidereal.configure` block.
- The Sourced integration reopens `Sidereal::Commander` to teach it the Sourced reactor protocol (`handled_messages`, `handle_claim`, `exclusive?`), sets `config.store`/`config.dispatcher`, and registers `Sidereal.exceptions` on Sourced's error strategy. Its `StoreProxy` delegates `#append` to `::Sourced.store` at call time so per-process reconnects are picked up.

### How the auto-publish notifications work

All three publish paths funnel through one helper, `Sidereal::Integrations::Sourced.publish_messages(messages)`, which publishes each message on its resolved channel (`Sidereal.channels.for(msg)`) and routes any publish/resolver failure to `Sidereal.exceptions.report_fatal` — a terminal error, since the store transaction has already committed and a retry would double-apply.

- **Deciders** publish the domain **events they emitted**. The integration reopens `Sourced::Decider` at require time and registers one generic `after_sync do |events:, **|` block. Because the integration loads before the app's domain reactors, Sourced's `Sync::ClassMethods#inherited` copies this block into every app Decider — no per-reactor wiring. Reaction-only batches emit no events, so the block is a no-op there.
- **Projectors** publish a synthetic **"projected" signal** so subscribed Pages re-fetch their read model. The integration prepends a module to `Sourced::Projector.singleton_class` that wraps the `partition_by` macro: declaring partition keys now also (a) auto-defines a `MyProjector::Projected` event class carrying one attribute per key, and (b) registers an `after_sync` that publishes an instance of it. The signal's payload is the projector's `partition_values` — the full claimed partition tuple straight off the instance — so it works for **any arity**, e.g. `partition_by(:student_id, :course_id)` yields a two-key signal, independent of what the projector writes into read-model state. Prepending to the singleton class resolves live, so it also covers the already-defined `StateStored`/`EventSourced` base classes and their subclasses.
- **Channel routing is unified.** Every path resolves its channel via the app's own `channel_name` resolver (`Sidereal.channels.for`). Because the generated `Projected` signal carries the partition keys, the app's existing resolver maps it to the same channel the projectors used to hand-compose — Pages subscribe with the same globs (`campaigns.>`, `games.>`) and reactions repoint from the old bespoke event to `MyProjector::Projected`.
- **No double-publish with Commanders.** Sidereal Commanders are a separate class hierarchy (duck-typed reactors, not `Decider`/`Projector` subclasses) and keep publishing via their own `handle_claim` action signal, so the injected hooks never touch them. Deleting the examples' manual `after_sync` blocks is what keeps the Decider/Projector paths single-publish.

### Multi-process topology guard

The in-process implementations (`Store::Memory`, `PubSub::Memory`, `Elector::AlwaysLeader`) carry a `Sidereal::SingleProcess` marker module. `Configuration#single_process_subsystems` returns the labels of whichever configured subsystems still carry it (empty after `use_file_system!`). At boot, the Falcon environment reads its worker-process count (`evaluator.count`, falling back to `Etc.nprocessors` for Falcon's `nil` "one per core" default) and calls `Sidereal.check_topology!(count)` **right after the app config loads and before the reactor starts** — so it fails fast. If `count > 1` and any subsystem is single-process, it logs a multi-line `Console.error` explaining the two failure modes and the two fixes (`use_file_system!`, or run a single worker) and `exit(1)`s. The classification lives on the implementations (the marker), the process-count knowledge stays in the Falcon adapter.

### Silencing benign SSE-disconnect warnings

`Console.logger` is fiber/thread-local (via the `fiber-local` gem), so a one-off `disable(Async::Task)` doesn't reach async-http's connection tasks — which is why the disconnect warnings leaked. Instead, `lib/sidereal/logging.rb` prepends a module onto `Console::Config#make_logger` — the single method the console gem uses to build **every** logger — so the `Async::Task` subject is disabled on each logger, on any thread or fiber. This is the programmatic equivalent of a project-level `config/console.rb`, but shipped in the gem so all apps get it for free; it works even though `Console::Config::DEFAULT` is already frozen (method resolution still walks the prepend). Set `CONSOLE_LEVEL=debug`/`=info` to re-enable full output.

- Specs cover `#use`, both integrations, the scheduler regression (a transient-fiber teardown test guarded by `Timeout`), the auto-publish behavior — decider event publishing, single-key projector signals, and a multi-key (`student_id` + `course_id`) projector proving the payload comes from `partition_values` rather than read-model state — plus `single_process_subsystems`/`check_topology!` (single-worker no-op, multi-worker error+exit, all-safe no-op) and the logger filter (every new logger disables `Async::Task`, idempotent install). The Sourced integration spec disconnects Sequel's SQLite connections after each example so the fork-based pubsub/store specs don't inherit a live connection and trip sqlite3's fork-safety warning.

## Notes

- The chat app's Gemfile points `sourced` at `github: 'ismasan/sourced', branch: 'ccc'`. The companion Sourced-side fix (always index the reserved `__id` key so id-partitioned reactors can claim messages appended by any process) lives in that repo and must land on the `ccc` branch for cross-process `dispatch!` to work end-to-end.
- **Replays** are not yet special-cased: a projector re-running its history republishes its `Projected` signal on every batch (same as the old hand-written behavior). Branching on the projector's `replaying:` flag is deferred.
- The disconnect-warning filter silences **all** `Async::Task` "ended with unhandled exception" warnings process-wide (the same blanket behavior Datastar already intended, just made reliable), so it could also hide a genuine task crash. `CONSOLE_LEVEL=debug` restores full output. A surgical version that drops only EPIPE/broken-pipe events would need a custom console output filter — deferred.
- The topology guard keys off worker-process count, which assumes forked (process) workers — Falcon's default. A threaded container shares memory, so in-process subsystems would be fine there and the guard would be a false positive; not handled, since forked is the standard Falcon setup.

